### PR TITLE
Add output worker role arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Available targets:
 | security_group_arn | ARN of the worker nodes Security Group |
 | security_group_id | ID of the worker nodes Security Group |
 | security_group_name | Name of the worker nodes Security Group |
+| worker_role_arn | ARN of the worker nodes IAM role |
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -88,4 +88,5 @@
 | security_group_arn | ARN of the worker nodes Security Group |
 | security_group_id | ID of the worker nodes Security Group |
 | security_group_name | Name of the worker nodes Security Group |
+| worker_role_arn | ARN of the worker nodes IAM role |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -70,7 +70,7 @@ output "security_group_name" {
 
 output "worker_role_arn" {
   description = "ARN of the worker nodes IAM role"
-  value       = "${aws_iam_role.default.arn}"
+  value       = "${join("", aws_iam_role.default.*.arn)}"
 }
 
 output "config_map_aws_auth" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -68,6 +68,11 @@ output "security_group_name" {
   value       = "${join("", aws_security_group.default.*.name)}"
 }
 
+output "worker_role_arn" {
+  description = "ARN of the worker nodes IAM role"
+  value       = "${aws_iam_role.default.arn}"
+}
+
 output "config_map_aws_auth" {
   description = "Kubernetes ConfigMap configuration for worker nodes to join the EKS cluster. https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#required-kubernetes-configuration-to-join-worker-nodes"
   value       = "${join("", data.template_file.config_map_aws_auth.*.rendered)}"


### PR DESCRIPTION
In order to template aws-acl in external place, ARN of the node needed. This may be useful for example if using two workers set within a cluster.