### PR TITLE
Get latest linux EKS Amazon liux AMI instead of windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Available targets:
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
 | disable_api_termination | If `true`, enables EC2 Instance Termination Protection | string | `false` | no |
 | ebs_optimized | If true, the launched EC2 instance will be EBS-optimized | string | `false` | no |
-| eks_worker_ami_name_filter | AMI name filter to lookup the most recent EKS AMI if `image_id` is not provided | string | `amazon-eks-node-v*` | no |
+| eks_worker_ami_name_filter | AMI name filter to lookup the most recent EKS AMI if `image_id` is not provided | string | `amazon-eks-node-*` | no |
 | elastic_gpu_specifications | Specifications of Elastic GPU to attach to the instances | list | `<list>` | no |
 | enable_monitoring | Enable/disable detailed monitoring | string | `true` | no |
 | enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | string | `true` | no |

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Available targets:
 | disable_api_termination | If `true`, enables EC2 Instance Termination Protection | string | `false` | no |
 | ebs_optimized | If true, the launched EC2 instance will be EBS-optimized | string | `false` | no |
 | eks_worker_ami_name_filter | AMI name filter to lookup the most recent EKS AMI if `image_id` is not provided | string | `amazon-eks-node-*` | no |
+| eks_worker_ami_name_regex | A regex string to apply to the AMI list returned by AWS | string | `^amazon-eks-node-[1-9,\.]+-v\d{8}$` | no |
 | elastic_gpu_specifications | Specifications of Elastic GPU to attach to the instances | list | `<list>` | no |
 | enable_monitoring | Enable/disable detailed monitoring | string | `true` | no |
 | enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | string | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -27,6 +27,7 @@
 | disable_api_termination | If `true`, enables EC2 Instance Termination Protection | string | `false` | no |
 | ebs_optimized | If true, the launched EC2 instance will be EBS-optimized | string | `false` | no |
 | eks_worker_ami_name_filter | AMI name filter to lookup the most recent EKS AMI if `image_id` is not provided | string | `amazon-eks-node-*` | no |
+| eks_worker_ami_name_regex | A regex string to apply to the AMI list returned by AWS | string | `^amazon-eks-node-[1-9,\.]+-v\d{8}$` | no |
 | elastic_gpu_specifications | Specifications of Elastic GPU to attach to the instances | list | `<list>` | no |
 | enable_monitoring | Enable/disable detailed monitoring | string | `true` | no |
 | enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | string | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -26,7 +26,7 @@
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
 | disable_api_termination | If `true`, enables EC2 Instance Termination Protection | string | `false` | no |
 | ebs_optimized | If true, the launched EC2 instance will be EBS-optimized | string | `false` | no |
-| eks_worker_ami_name_filter | AMI name filter to lookup the most recent EKS AMI if `image_id` is not provided | string | `amazon-eks-node-v*` | no |
+| eks_worker_ami_name_filter | AMI name filter to lookup the most recent EKS AMI if `image_id` is not provided | string | `amazon-eks-node-*` | no |
 | elastic_gpu_specifications | Specifications of Elastic GPU to attach to the instances | list | `<list>` | no |
 | enable_monitoring | Enable/disable detailed monitoring | string | `true` | no |
 | enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | string | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -121,10 +121,10 @@ resource "aws_security_group_rule" "ingress_cidr_blocks" {
 }
 
 data "aws_ami" "eks_worker" {
-  count = "${var.enabled == "true" && var.image_id == "" ? 1 : 0}"
-  most_recent      = true
-  name_regex       = "^amazon-eks-node-[1-9,\\.]+-v\\d{8}$" 
-  
+  count       = "${var.enabled == "true" && var.image_id == "" ? 1 : 0}"
+  most_recent = true
+  name_regex  = "^amazon-eks-node-[1-9,\\.]+-v\\d{8}$"
+
   filter {
     name   = "name"
     values = ["${var.eks_worker_ami_name_filter}"]

--- a/main.tf
+++ b/main.tf
@@ -123,7 +123,7 @@ resource "aws_security_group_rule" "ingress_cidr_blocks" {
 data "aws_ami" "eks_worker" {
   count       = "${var.enabled == "true" && var.image_id == "" ? 1 : 0}"
   most_recent = true
-  name_regex  = "^amazon-eks-node-[1-9,\\.]+-v\\d{8}$"
+  name_regex  = "${var.eks_worker_ami_name_regex}"
 
   filter {
     name   = "name"

--- a/main.tf
+++ b/main.tf
@@ -122,7 +122,9 @@ resource "aws_security_group_rule" "ingress_cidr_blocks" {
 
 data "aws_ami" "eks_worker" {
   count = "${var.enabled == "true" && var.image_id == "" ? 1 : 0}"
-
+  most_recent      = true
+  name_regex       = "^amazon-eks-node-[1-9,\\.]+-v\\d{8}$" 
+  
   filter {
     name   = "name"
     values = ["${var.eks_worker_ami_name_filter}"]

--- a/variables.tf
+++ b/variables.tf
@@ -99,6 +99,12 @@ variable "eks_worker_ami_name_filter" {
   default     = "amazon-eks-node-*"
 }
 
+variable "eks_worker_ami_name_regex" {
+  type        = "string"
+  description = "A regex string to apply to the AMI list returned by AWS"
+  default     = "^amazon-eks-node-[1-9,\\.]+-v\\d{8}$"
+}
+
 variable "instance_type" {
   type        = "string"
   description = "Instance type to launch"

--- a/variables.tf
+++ b/variables.tf
@@ -96,7 +96,7 @@ variable "image_id" {
 variable "eks_worker_ami_name_filter" {
   type        = "string"
   description = "AMI name filter to lookup the most recent EKS AMI if `image_id` is not provided"
-  default     = "amazon-eks-node-v*"
+  default     = "amazon-eks-node-*"
 }
 
 variable "instance_type" {


### PR DESCRIPTION
aws ec2 describe-images --filters "Name=name,Values=amazon-eks-node-v*" --query 'Images[].Name'
[
    "amazon-eks-node-v1.11-windows-2019-Full-1553550739", 
    "amazon-eks-node-v1.11-windows-2019-Core-1553550738"
]

aws ec2 describe-images --filters "Name=name,Values=amazon-eks-node-*" --query 'Images[].Name' 
[
    "amazon-eks-node-1.10-v20190329", 
    "amazon-eks-node-1.10-v20190220", 
    "amazon-eks-node-1.11-v20181210", 
    "amazon-eks-node-v1.11-windows-2019-Full-1553550739", 
    "amazon-eks-node-1.10-v20181210", 
    "amazon-eks-node-1.11-v20190327", 
    "amazon-eks-node-1.11-v20190329", 
    "amazon-eks-node-1.11-v20190109", 
    "amazon-eks-node-1.12-v20190327", 
    "amazon-eks-node-v1.11-windows-2019-Core-1553550738", 
    "amazon-eks-node-1.11-v20190211", 
    "amazon-eks-node-1.10-v20190109", 
    "amazon-eks-node-1.10-v20190327", 
    "amazon-eks-node-1.11-v20190220", 
    "amazon-eks-node-1.12-v20190329", 
    "amazon-eks-node-1.10-v20190211"
]
