### PR TITLE
add possibility to use image_id without creating it in different stat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Available targets:
 | tags | Additional tags (e.g. `{ BusinessUnit = "XYZ" }` | map | `<map>` | no |
 | target_group_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
 | termination_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default` | list | `<list>` | no |
-| use_custom_image_id | if true will use variable image_id to run EKS workers inside autoscaling group | string | `false` | no |
+| use_custom_image_id | if `true` will use variable `image_id` to run EKS workers inside autoscaling group | string | `false` | no |
 | vpc_id | VPC ID for the EKS cluster | string | - | yes |
 | wait_for_capacity_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | string | `10m` | no |
 | wait_for_elb_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | string | `false` | no |

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Available targets:
 | tags | Additional tags (e.g. `{ BusinessUnit = "XYZ" }` | map | `<map>` | no |
 | target_group_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
 | termination_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default` | list | `<list>` | no |
+| use_custom_image_id | if true will use variable image_id to run EKS workers inside autoscaling group | string | `false` | no |
 | vpc_id | VPC ID for the EKS cluster | string | - | yes |
 | wait_for_capacity_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | string | `10m` | no |
 | wait_for_elb_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | string | `false` | no |

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Available targets:
 | tags | Additional tags (e.g. `{ BusinessUnit = "XYZ" }` | map | `<map>` | no |
 | target_group_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
 | termination_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default` | list | `<list>` | no |
-| use_custom_image_id | If `true` will use variable `image_id` to run EKS workers inside autoscaling group | string | `false` | no |
+| use_custom_image_id | If set to `true`, will use variable `image_id` to run EKS workers inside autoscaling group | string | `false` | no |
 | vpc_id | VPC ID for the EKS cluster | string | - | yes |
 | wait_for_capacity_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | string | `10m` | no |
 | wait_for_elb_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | string | `false` | no |

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Available targets:
 | tags | Additional tags (e.g. `{ BusinessUnit = "XYZ" }` | map | `<map>` | no |
 | target_group_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
 | termination_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default` | list | `<list>` | no |
-| use_custom_image_id | if `true` will use variable `image_id` to run EKS workers inside autoscaling group | string | `false` | no |
+| use_custom_image_id | If `true` will use variable `image_id` to run EKS workers inside autoscaling group | string | `false` | no |
 | vpc_id | VPC ID for the EKS cluster | string | - | yes |
 | wait_for_capacity_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | string | `10m` | no |
 | wait_for_elb_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | string | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -66,7 +66,7 @@
 | tags | Additional tags (e.g. `{ BusinessUnit = "XYZ" }` | map | `<map>` | no |
 | target_group_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
 | termination_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default` | list | `<list>` | no |
-| use_custom_image_id | If `true` will use variable `image_id` to run EKS workers inside autoscaling group | string | `false` | no |
+| use_custom_image_id | If set to `true`, will use variable `image_id` to run EKS workers inside autoscaling group | string | `false` | no |
 | vpc_id | VPC ID for the EKS cluster | string | - | yes |
 | wait_for_capacity_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | string | `10m` | no |
 | wait_for_elb_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | string | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -66,6 +66,7 @@
 | tags | Additional tags (e.g. `{ BusinessUnit = "XYZ" }` | map | `<map>` | no |
 | target_group_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
 | termination_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default` | list | `<list>` | no |
+| use_custom_image_id | if true will use variable image_id to run EKS workers inside autoscaling group | string | `false` | no |
 | vpc_id | VPC ID for the EKS cluster | string | - | yes |
 | wait_for_capacity_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | string | `10m` | no |
 | wait_for_elb_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | string | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -66,7 +66,7 @@
 | tags | Additional tags (e.g. `{ BusinessUnit = "XYZ" }` | map | `<map>` | no |
 | target_group_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
 | termination_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default` | list | `<list>` | no |
-| use_custom_image_id | if `true` will use variable `image_id` to run EKS workers inside autoscaling group | string | `false` | no |
+| use_custom_image_id | If `true` will use variable `image_id` to run EKS workers inside autoscaling group | string | `false` | no |
 | vpc_id | VPC ID for the EKS cluster | string | - | yes |
 | wait_for_capacity_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | string | `10m` | no |
 | wait_for_elb_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | string | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -66,7 +66,7 @@
 | tags | Additional tags (e.g. `{ BusinessUnit = "XYZ" }` | map | `<map>` | no |
 | target_group_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
 | termination_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default` | list | `<list>` | no |
-| use_custom_image_id | if true will use variable image_id to run EKS workers inside autoscaling group | string | `false` | no |
+| use_custom_image_id | if `true` will use variable `image_id` to run EKS workers inside autoscaling group | string | `false` | no |
 | vpc_id | VPC ID for the EKS cluster | string | - | yes |
 | wait_for_capacity_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | string | `10m` | no |
 | wait_for_elb_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | string | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -121,7 +121,7 @@ resource "aws_security_group_rule" "ingress_cidr_blocks" {
 }
 
 data "aws_ami" "eks_worker" {
-  count = "${var.enabled == "true" && var.use_custom_image_id ? 1 : 0}"
+  count = "${var.enabled == "true" && var.use_custom_image_id == "true" ? 1 : 0}"
 
   most_recent = true
   name_regex  = "${var.eks_worker_ami_name_regex}"
@@ -145,7 +145,7 @@ module "autoscale_group" {
   delimiter  = "${var.delimiter}"
   attributes = "${var.attributes}"
 
-  image_id                  = "${var.use_custom_image_id ? var.image_id : join("", data.aws_ami.eks_worker.*.id)}"
+  image_id                  = "${var.use_custom_image_id == "true" ? var.image_id : join("", data.aws_ami.eks_worker.*.id)}"
   iam_instance_profile_name = "${join("", aws_iam_instance_profile.default.*.name)}"
   security_group_ids        = ["${join("", aws_security_group.default.*.id)}"]
   user_data_base64          = "${base64encode(join("", data.template_file.userdata.*.rendered))}"

--- a/main.tf
+++ b/main.tf
@@ -121,7 +121,7 @@ resource "aws_security_group_rule" "ingress_cidr_blocks" {
 }
 
 data "aws_ami" "eks_worker" {
-  count = "${var.enabled == "true" && var.use_custom_image_id == "true" ? 1 : 0}"
+  count = "${var.enabled == "true" && var.use_custom_image_id == "false" ? 1 : 0}"
 
   most_recent = true
   name_regex  = "${var.eks_worker_ami_name_regex}"

--- a/main.tf
+++ b/main.tf
@@ -121,7 +121,7 @@ resource "aws_security_group_rule" "ingress_cidr_blocks" {
 }
 
 data "aws_ami" "eks_worker" {
-  count = "${var.enabled == "true" && var.image_id == "" ? 1 : 0}"
+  count = "${var.enabled == "true" && var.use_custom_image_id ? 1 : 0}"
 
   filter {
     name   = "name"
@@ -142,7 +142,7 @@ module "autoscale_group" {
   delimiter  = "${var.delimiter}"
   attributes = "${var.attributes}"
 
-  image_id                  = "${coalesce(var.image_id, join("", data.aws_ami.eks_worker.*.id))}"
+  image_id                  = "${var.use_custom_image_id ? var.image_id : join("", data.aws_ami.eks_worker.*.id)}"
   iam_instance_profile_name = "${join("", aws_iam_instance_profile.default.*.name)}"
   security_group_ids        = ["${join("", aws_security_group.default.*.id)}"]
   user_data_base64          = "${base64encode(join("", data.template_file.userdata.*.rendered))}"

--- a/variables.tf
+++ b/variables.tf
@@ -95,7 +95,7 @@ variable "image_id" {
 
 variable "use_custom_image_id" {
   type        = "string"
-  description = "If `true` will use variable `image_id` to run EKS workers inside autoscaling group"
+  description = "If set to `true`, will use variable `image_id` to run EKS workers inside autoscaling group"
   default     = "false"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -95,7 +95,7 @@ variable "image_id" {
 
 variable "use_custom_image_id" {
   type        = "string"
-  description = "if `true` will use variable `image_id` to run EKS workers inside autoscaling group"
+  description = "If `true` will use variable `image_id` to run EKS workers inside autoscaling group"
   default     = "false"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,11 @@ variable "image_id" {
   default     = ""
 }
 
+variable "use_custom_image_id" {
+  description = "if true will use variable image_id to run EKS workers inside autoscaling group"
+  default     = false
+}
+
 variable "eks_worker_ami_name_filter" {
   type        = "string"
   description = "AMI name filter to lookup the most recent EKS AMI if `image_id` is not provided"

--- a/variables.tf
+++ b/variables.tf
@@ -95,7 +95,7 @@ variable "image_id" {
 
 variable "use_custom_image_id" {
   type        = "string"
-  description = "if true will use variable image_id to run EKS workers inside autoscaling group"
+  description = "if `true` will use variable `image_id` to run EKS workers inside autoscaling group"
   default     = "false"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -94,8 +94,9 @@ variable "image_id" {
 }
 
 variable "use_custom_image_id" {
+  type        = "string"
   description = "if true will use variable image_id to run EKS workers inside autoscaling group"
-  default     = false
+  default     = "false"
 }
 
 variable "eks_worker_ami_name_filter" {


### PR DESCRIPTION
add possibility to use image_id without creating it in different state than cluster,
I use it to create encrypted ami for eks workers, do you interested to add part of code that will create custom ami with encrypted root disk for this module?