### PR TITLE
Add role name output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 **/.build-harness
 **/build-harness
+
+# vim editor
+*.swp

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Available targets:
 | associate_public_ip_address | Associate a public IP address with an instance in a VPC | string | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | autoscaling_policies_enabled | Whether to create `aws_autoscaling_policy` and `aws_cloudwatch_metric_alarm` resources to control Auto Scaling | string | `true` | no |
+| aws_iam_instance_profile | Use this to provide already existed instance profile that will be used in autoscaling group for EKS workers, if empty will create instance profile for you. | string | `` | no |
 | block_device_mappings | Specify volumes to attach to the instance besides the volumes specified by the AMI | list | `<list>` | no |
 | bootstrap_extra_args | Passed to the bootstrap.sh script to enable --kublet-extra-args or --use-max-pods. | string | `` | no |
 | cluster_certificate_authority_data | The base64 encoded certificate data required to communicate with the cluster | string | - | yes |
@@ -208,6 +209,7 @@ Available targets:
 | target_group_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
 | termination_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default` | list | `<list>` | no |
 | use_custom_image_id | If set to `true`, will use variable `image_id` to run EKS workers inside autoscaling group | string | `false` | no |
+| use_provided_aws_iam_instance_profile | When `true`, will use already existed instance profile and provided in variable `aws_iam_instance_profile` | string | `false` | no |
 | vpc_id | VPC ID for the EKS cluster | string | - | yes |
 | wait_for_capacity_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | string | `10m` | no |
 | wait_for_elb_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | string | `false` | no |
@@ -232,6 +234,7 @@ Available targets:
 | security_group_id | ID of the worker nodes Security Group |
 | security_group_name | Name of the worker nodes Security Group |
 | worker_role_arn | ARN of the worker nodes IAM role |
+| worker_role_name | Name of the worker nodes IAM role |
 
 
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Available targets:
 | associate_public_ip_address | Associate a public IP address with an instance in a VPC | string | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | autoscaling_policies_enabled | Whether to create `aws_autoscaling_policy` and `aws_cloudwatch_metric_alarm` resources to control Auto Scaling | string | `true` | no |
-| aws_iam_instance_profile | Use this to provide already existed instance profile that will be used in autoscaling group for EKS workers, if empty will create instance profile for you. | string | `` | no |
+| aws_iam_instance_profile_name | The name of the existing instance profile that will be used in autoscaling group for EKS workers. If empty will create a new instance profile. | string | `` | no |
 | block_device_mappings | Specify volumes to attach to the instance besides the volumes specified by the AMI | list | `<list>` | no |
 | bootstrap_extra_args | Passed to the bootstrap.sh script to enable --kublet-extra-args or --use-max-pods. | string | `` | no |
 | cluster_certificate_authority_data | The base64 encoded certificate data required to communicate with the cluster | string | - | yes |
@@ -209,7 +209,6 @@ Available targets:
 | target_group_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
 | termination_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default` | list | `<list>` | no |
 | use_custom_image_id | If set to `true`, will use variable `image_id` to run EKS workers inside autoscaling group | string | `false` | no |
-| use_provided_aws_iam_instance_profile | When `true`, will use already existed instance profile provided in variable `aws_iam_instance_profile` | string | `false` | no |
 | vpc_id | VPC ID for the EKS cluster | string | - | yes |
 | wait_for_capacity_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | string | `10m` | no |
 | wait_for_elb_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | string | `false` | no |

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Available targets:
 | target_group_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
 | termination_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default` | list | `<list>` | no |
 | use_custom_image_id | If set to `true`, will use variable `image_id` to run EKS workers inside autoscaling group | string | `false` | no |
-| use_provided_aws_iam_instance_profile | When `true`, will use already existed instance profile and provided in variable `aws_iam_instance_profile` | string | `false` | no |
+| use_provided_aws_iam_instance_profile | When `true`, will use already existed instance profile provided in variable `aws_iam_instance_profile` | string | `false` | no |
 | vpc_id | VPC ID for the EKS cluster | string | - | yes |
 | wait_for_capacity_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | string | `10m` | no |
 | wait_for_elb_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | string | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,6 +7,7 @@
 | associate_public_ip_address | Associate a public IP address with an instance in a VPC | string | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | autoscaling_policies_enabled | Whether to create `aws_autoscaling_policy` and `aws_cloudwatch_metric_alarm` resources to control Auto Scaling | string | `true` | no |
+| aws_iam_instance_profile | Use this to provide already existed instance profile that will be used in autoscaling group for EKS workers, if empty will create instance profile for you. | string | `` | no |
 | block_device_mappings | Specify volumes to attach to the instance besides the volumes specified by the AMI | list | `<list>` | no |
 | bootstrap_extra_args | Passed to the bootstrap.sh script to enable --kublet-extra-args or --use-max-pods. | string | `` | no |
 | cluster_certificate_authority_data | The base64 encoded certificate data required to communicate with the cluster | string | - | yes |
@@ -67,6 +68,7 @@
 | target_group_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
 | termination_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default` | list | `<list>` | no |
 | use_custom_image_id | If set to `true`, will use variable `image_id` to run EKS workers inside autoscaling group | string | `false` | no |
+| use_provided_aws_iam_instance_profile | When `true`, will use already existed instance profile and provided in variable `aws_iam_instance_profile` | string | `false` | no |
 | vpc_id | VPC ID for the EKS cluster | string | - | yes |
 | wait_for_capacity_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | string | `10m` | no |
 | wait_for_elb_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | string | `false` | no |
@@ -91,4 +93,5 @@
 | security_group_id | ID of the worker nodes Security Group |
 | security_group_name | Name of the worker nodes Security Group |
 | worker_role_arn | ARN of the worker nodes IAM role |
+| worker_role_name | Name of the worker nodes IAM role |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,7 +7,7 @@
 | associate_public_ip_address | Associate a public IP address with an instance in a VPC | string | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | autoscaling_policies_enabled | Whether to create `aws_autoscaling_policy` and `aws_cloudwatch_metric_alarm` resources to control Auto Scaling | string | `true` | no |
-| aws_iam_instance_profile | Use this to provide already existed instance profile that will be used in autoscaling group for EKS workers, if empty will create instance profile for you. | string | `` | no |
+| aws_iam_instance_profile_name | The name of the existing instance profile that will be used in autoscaling group for EKS workers. If empty will create a new instance profile. | string | `` | no |
 | block_device_mappings | Specify volumes to attach to the instance besides the volumes specified by the AMI | list | `<list>` | no |
 | bootstrap_extra_args | Passed to the bootstrap.sh script to enable --kublet-extra-args or --use-max-pods. | string | `` | no |
 | cluster_certificate_authority_data | The base64 encoded certificate data required to communicate with the cluster | string | - | yes |
@@ -68,7 +68,6 @@
 | target_group_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
 | termination_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default` | list | `<list>` | no |
 | use_custom_image_id | If set to `true`, will use variable `image_id` to run EKS workers inside autoscaling group | string | `false` | no |
-| use_provided_aws_iam_instance_profile | When `true`, will use already existed instance profile provided in variable `aws_iam_instance_profile` | string | `false` | no |
 | vpc_id | VPC ID for the EKS cluster | string | - | yes |
 | wait_for_capacity_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | string | `10m` | no |
 | wait_for_elb_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | string | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -68,7 +68,7 @@
 | target_group_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
 | termination_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default` | list | `<list>` | no |
 | use_custom_image_id | If set to `true`, will use variable `image_id` to run EKS workers inside autoscaling group | string | `false` | no |
-| use_provided_aws_iam_instance_profile | When `true`, will use already existed instance profile and provided in variable `aws_iam_instance_profile` | string | `false` | no |
+| use_provided_aws_iam_instance_profile | When `true`, will use already existed instance profile provided in variable `aws_iam_instance_profile` | string | `false` | no |
 | vpc_id | VPC ID for the EKS cluster | string | - | yes |
 | wait_for_capacity_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | string | `10m` | no |
 | wait_for_elb_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | string | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ module "label" {
 }
 
 data "aws_iam_policy_document" "assume_role" {
-  count = "${var.enabled == "true" ? 1 : 0}"
+  count = "${var.enabled == "true" && var.use_provided_aws_iam_instance_profile == "false" ? 1 : 0}"
 
   statement {
     effect  = "Allow"
@@ -28,31 +28,31 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "default" {
-  count              = "${var.enabled == "true" ? 1 : 0}"
+  count              = "${var.enabled == "true" && var.use_provided_aws_iam_instance_profile == "false" ? 1 : 0}"
   name               = "${module.label.id}"
   assume_role_policy = "${join("", data.aws_iam_policy_document.assume_role.*.json)}"
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_worker_node_policy" {
-  count      = "${var.enabled == "true" ? 1 : 0}"
+  count      = "${var.enabled == "true" && var.use_provided_aws_iam_instance_profile == "false" ? 1 : 0}"
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
   role       = "${join("", aws_iam_role.default.*.name)}"
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_cni_policy" {
-  count      = "${var.enabled == "true" ? 1 : 0}"
+  count      = "${var.enabled == "true" && var.use_provided_aws_iam_instance_profile == "false" ? 1 : 0}"
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
   role       = "${join("", aws_iam_role.default.*.name)}"
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_ec2_container_registry_read_only" {
-  count      = "${var.enabled == "true" ? 1 : 0}"
+  count      = "${var.enabled == "true" && var.use_provided_aws_iam_instance_profile == "false" ? 1 : 0}"
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
   role       = "${join("", aws_iam_role.default.*.name)}"
 }
 
 resource "aws_iam_instance_profile" "default" {
-  count = "${var.enabled == "true" ? 1 : 0}"
+  count = "${var.enabled == "true" && var.use_provided_aws_iam_instance_profile == "false" ? 1 : 0}"
   name  = "${module.label.id}"
   role  = "${join("", aws_iam_role.default.*.name)}"
 }
@@ -146,7 +146,7 @@ module "autoscale_group" {
   attributes = "${var.attributes}"
 
   image_id                  = "${var.use_custom_image_id == "true" ? var.image_id : join("", data.aws_ami.eks_worker.*.id)}"
-  iam_instance_profile_name = "${join("", aws_iam_instance_profile.default.*.name)}"
+  iam_instance_profile_name = "${var.use_provided_aws_iam_instance_profile == "false" ? join("", aws_iam_instance_profile.default.*.name) : var.aws_iam_instance_profile}"
   security_group_ids        = ["${join("", aws_security_group.default.*.id)}"]
   user_data_base64          = "${base64encode(join("", data.template_file.userdata.*.rendered))}"
   tags                      = "${module.label.tags}"

--- a/main.tf
+++ b/main.tf
@@ -213,11 +213,16 @@ data "template_file" "userdata" {
   }
 }
 
+data "aws_iam_instance_profile" "default" {
+  count = "${var.enabled == "true" && var.use_provided_aws_iam_instance_profile == "false" ? 1 : 0}"
+  name  = "${var.aws_iam_instance_profile}"
+}
+
 data "template_file" "config_map_aws_auth" {
   count    = "${var.enabled == "true" ? 1 : 0}"
   template = "${file("${path.module}/config_map_aws_auth.tpl")}"
 
   vars {
-    aws_iam_role_arn = "${join("", aws_iam_role.default.*.arn)}"
+    aws_iam_role_arn = "${var.use_provided_aws_iam_instance_profile == "false" ? join("", aws_iam_role.default.*.arn) : data.aws_iam_instance_profile.default.role_arn}"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -223,6 +223,6 @@ data "template_file" "config_map_aws_auth" {
   template = "${file("${path.module}/config_map_aws_auth.tpl")}"
 
   vars {
-    aws_iam_role_arn = "${var.use_provided_aws_iam_instance_profile == "true" ? data.aws_iam_instance_profile.default.role_arn : join("", aws_iam_role.default.*.arn)}"
+    aws_iam_role_arn = "${var.use_provided_aws_iam_instance_profile == "true" ?  join("", data.aws_iam_instance_profile.default.*.role_arn) : join("", aws_iam_role.default.*.arn)}"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -214,7 +214,7 @@ data "template_file" "userdata" {
 }
 
 data "aws_iam_instance_profile" "default" {
-  count = "${var.enabled == "true" && var.use_provided_aws_iam_instance_profile == "false" ? 1 : 0}"
+  count = "${var.enabled == "true" && var.use_provided_aws_iam_instance_profile == "true" ? 1 : 0}"
   name  = "${var.aws_iam_instance_profile}"
 }
 
@@ -223,6 +223,6 @@ data "template_file" "config_map_aws_auth" {
   template = "${file("${path.module}/config_map_aws_auth.tpl")}"
 
   vars {
-    aws_iam_role_arn = "${var.use_provided_aws_iam_instance_profile == "false" ? join("", aws_iam_role.default.*.arn) : data.aws_iam_instance_profile.default.role_arn}"
+    aws_iam_role_arn = "${var.use_provided_aws_iam_instance_profile == "true" ? data.aws_iam_instance_profile.default.role_arn : join("", aws_iam_role.default.*.arn)}"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
   tags = "${merge(var.tags, map("kubernetes.io/cluster/${var.cluster_name}", "owned"))}"
+  use_existing_instance_profile = "${var.aws_iam_instance_profile_name != "" ? "true" : "false"}"
 }
 
 module "label" {
@@ -14,7 +15,7 @@ module "label" {
 }
 
 data "aws_iam_policy_document" "assume_role" {
-  count = "${var.enabled == "true" && var.use_provided_aws_iam_instance_profile == "false" ? 1 : 0}"
+  count = "${var.enabled == "true" && local.use_existing_instance_profile == "false" ? 1 : 0}"
 
   statement {
     effect  = "Allow"
@@ -28,31 +29,31 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "default" {
-  count              = "${var.enabled == "true" && var.use_provided_aws_iam_instance_profile == "false" ? 1 : 0}"
+  count              = "${var.enabled == "true" && local.use_existing_instance_profile == "false" ? 1 : 0}"
   name               = "${module.label.id}"
   assume_role_policy = "${join("", data.aws_iam_policy_document.assume_role.*.json)}"
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_worker_node_policy" {
-  count      = "${var.enabled == "true" && var.use_provided_aws_iam_instance_profile == "false" ? 1 : 0}"
+  count      = "${var.enabled == "true" && local.use_existing_instance_profile == "false" ? 1 : 0}"
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
   role       = "${join("", aws_iam_role.default.*.name)}"
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_cni_policy" {
-  count      = "${var.enabled == "true" && var.use_provided_aws_iam_instance_profile == "false" ? 1 : 0}"
+  count      = "${var.enabled == "true" && local.use_existing_instance_profile == "false" ? 1 : 0}"
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
   role       = "${join("", aws_iam_role.default.*.name)}"
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_ec2_container_registry_read_only" {
-  count      = "${var.enabled == "true" && var.use_provided_aws_iam_instance_profile == "false" ? 1 : 0}"
+  count      = "${var.enabled == "true" && local.use_existing_instance_profile == "false" ? 1 : 0}"
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
   role       = "${join("", aws_iam_role.default.*.name)}"
 }
 
 resource "aws_iam_instance_profile" "default" {
-  count = "${var.enabled == "true" && var.use_provided_aws_iam_instance_profile == "false" ? 1 : 0}"
+  count = "${var.enabled == "true" && local.use_existing_instance_profile == "false" ? 1 : 0}"
   name  = "${module.label.id}"
   role  = "${join("", aws_iam_role.default.*.name)}"
 }
@@ -146,7 +147,7 @@ module "autoscale_group" {
   attributes = "${var.attributes}"
 
   image_id                  = "${var.use_custom_image_id == "true" ? var.image_id : join("", data.aws_ami.eks_worker.*.id)}"
-  iam_instance_profile_name = "${var.use_provided_aws_iam_instance_profile == "false" ? join("", aws_iam_instance_profile.default.*.name) : var.aws_iam_instance_profile}"
+  iam_instance_profile_name = "${local.use_existing_instance_profile == "false" ? join("", aws_iam_instance_profile.default.*.name) : var.aws_iam_instance_profile_name}"
   security_group_ids        = ["${join("", aws_security_group.default.*.id)}"]
   user_data_base64          = "${base64encode(join("", data.template_file.userdata.*.rendered))}"
   tags                      = "${module.label.tags}"
@@ -214,8 +215,8 @@ data "template_file" "userdata" {
 }
 
 data "aws_iam_instance_profile" "default" {
-  count = "${var.enabled == "true" && var.use_provided_aws_iam_instance_profile == "true" ? 1 : 0}"
-  name  = "${var.aws_iam_instance_profile}"
+  count = "${var.enabled == "true" && local.use_existing_instance_profile == "true" ? 1 : 0}"
+  name  = "${var.aws_iam_instance_profile_name}"
 }
 
 data "template_file" "config_map_aws_auth" {
@@ -223,6 +224,6 @@ data "template_file" "config_map_aws_auth" {
   template = "${file("${path.module}/config_map_aws_auth.tpl")}"
 
   vars {
-    aws_iam_role_arn = "${var.use_provided_aws_iam_instance_profile == "true" ?  join("", data.aws_iam_instance_profile.default.*.role_arn) : join("", aws_iam_role.default.*.arn)}"
+    aws_iam_role_arn = "${local.use_existing_instance_profile == "true" ?  join("", data.aws_iam_instance_profile.default.*.role_arn) : join("", aws_iam_role.default.*.arn)}"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  tags = "${merge(var.tags, map("kubernetes.io/cluster/${var.cluster_name}", "owned"))}"
+  tags                          = "${merge(var.tags, map("kubernetes.io/cluster/${var.cluster_name}", "owned"))}"
   use_existing_instance_profile = "${var.aws_iam_instance_profile_name != "" ? "true" : "false"}"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -73,6 +73,11 @@ output "worker_role_arn" {
   value       = "${join("", aws_iam_role.default.*.arn)}"
 }
 
+output "worker_role_name" {
+  description = "Name of the worker nodes IAM role"
+  value       = "${join("", aws_iam_role.default.*.name)}"
+}
+
 output "config_map_aws_auth" {
   description = "Kubernetes ConfigMap configuration for worker nodes to join the EKS cluster. https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#required-kubernetes-configuration-to-join-worker-nodes"
   value       = "${join("", data.template_file.config_map_aws_auth.*.rendered)}"

--- a/variables.tf
+++ b/variables.tf
@@ -390,3 +390,15 @@ variable "bootstrap_extra_args" {
   default     = ""
   description = "Passed to the bootstrap.sh script to enable --kublet-extra-args or --use-max-pods."
 }
+
+variable "aws_iam_instance_profile" {
+  type        = "string"
+  default     = ""
+  description = "Use this to provide already existed instance profile that will be used in autoscaling group for EKS workers, if empty will create instance profile for you."
+}
+
+variable "use_provided_aws_iam_instance_profile" {
+  type        = "string"
+  default     = "false"
+  description = "When `true`, will use already existed instance profile provided in variable `aws_iam_instance_profile`"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -391,14 +391,8 @@ variable "bootstrap_extra_args" {
   description = "Passed to the bootstrap.sh script to enable --kublet-extra-args or --use-max-pods."
 }
 
-variable "aws_iam_instance_profile" {
+variable "aws_iam_instance_profile_name" {
   type        = "string"
   default     = ""
-  description = "Use this to provide already existed instance profile that will be used in autoscaling group for EKS workers, if empty will create instance profile for you."
-}
-
-variable "use_provided_aws_iam_instance_profile" {
-  type        = "string"
-  default     = "false"
-  description = "When `true`, will use already existed instance profile provided in variable `aws_iam_instance_profile`"
+  description = "The name of the existing instance profile that will be used in autoscaling group for EKS workers. If empty will create a new instance profile."
 }


### PR DESCRIPTION
1) add output worker_role_name to use for attach additional policy to existing worker role
2) add possibility to use existed instance profile for workers, useful when you have multiple EKS workers group