### PR TITLE
Bootstrap workers with the docker bridge

### DIFF
--- a/userdata.tpl
+++ b/userdata.tpl
@@ -3,4 +3,4 @@
 # userdata for EKS worker nodes to properly configure Kubernetes applications on EC2 instances
 # https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html
 
-/etc/eks/bootstrap.sh --apiserver-endpoint '${cluster_endpoint}' --b64-cluster-ca '${certificate_authority_data}' ${bootstrap_extra_args} '${cluster_name}'
+/etc/eks/bootstrap.sh --enable-docker-bridge true --apiserver-endpoint '${cluster_endpoint}' --b64-cluster-ca '${certificate_authority_data}' ${bootstrap_extra_args} '${cluster_name}'


### PR DESCRIPTION
See https://github.com/awslabs/amazon-eks-ami/issues/183. According to AWS support, adding the default bridge support is needed in order for docker in or docker on docker to build images inside of a pod.

(moving fast, but let me know of any desired changes here and I'll adjust)