### PR TITLE
updates to hcl2 syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,69 +58,69 @@ For a complete example, see [examples/complete](examples/complete)
 
 ```hcl
 provider "aws" {
-  region = "${var.region}"
+  region = var.region
 }
 
 locals {
   # The usage of the specific kubernetes.io/cluster/* resource tags below are required
   # for EKS and Kubernetes to discover and manage networking resources
   # https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#base-vpc-networking
-  tags = "${merge(var.tags, map("kubernetes.io/cluster/${var.cluster_name}", "shared"))}"
+  tags = merge(var.tags, map("kubernetes.io/cluster/${var.cluster_name}", "shared"))
 }
 
 data "aws_availability_zones" "available" {}
 
 module "vpc" {
   source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  attributes = "${var.attributes}"
-  tags       = "${local.tags}"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  attributes = var.attributes
+  tags       = local.tags
   cidr_block = "10.0.0.0/16"
 }
 
 module "subnets" {
   source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=master"
-  availability_zones  = ["${data.aws_availability_zones.available.names}"]
-  namespace           = "${var.namespace}"
-  stage               = "${var.stage}"
-  name                = "${var.name}"
-  attributes          = "${var.attributes}"
-  tags                = "${local.tags}"
-  region              = "${var.region}"
-  vpc_id              = "${module.vpc.vpc_id}"
-  igw_id              = "${module.vpc.igw_id}"
-  cidr_block          = "${module.vpc.vpc_cidr_block}"
+  availability_zones  = [data.aws_availability_zones.available.names]
+  namespace           = var.namespace
+  stage               = var.stage
+  name                = var.name
+  attributes          = var.attributes
+  tags                = local.tags
+  region              = var.region
+  vpc_id              = module.vpc.vpc_id
+  igw_id              = module.vpc.igw_id
+  cidr_block          = module.vpc.vpc_cidr_block
   nat_gateway_enabled = "true"
 }
 
 module "eks_workers" {
   source                             = "git::https://github.com/cloudposse/terraform-aws-eks-workers.git?ref=master"
-  namespace                          = "${var.namespace}"
-  stage                              = "${var.stage}"
-  name                               = "${var.name}"
-  attributes                         = "${var.attributes}"
-  tags                               = "${var.tags}"
-  image_id                           = "${var.image_id}"
-  eks_worker_ami_name_filter         = "${var.eks_worker_ami_name_filter}"
-  instance_type                      = "${var.instance_type}"
-  vpc_id                             = "${module.vpc.vpc_id}"
-  subnet_ids                         = ["${module.subnets.public_subnet_ids}"]
-  health_check_type                  = "${var.health_check_type}"
-  min_size                           = "${var.min_size}"
-  max_size                           = "${var.max_size}"
-  wait_for_capacity_timeout          = "${var.wait_for_capacity_timeout}"
-  associate_public_ip_address        = "${var.associate_public_ip_address}"
-  cluster_name                       = "${var.cluster_name}"
-  cluster_endpoint                   = "${var.cluster_endpoint}"
-  cluster_certificate_authority_data = "${var.cluster_certificate_authority_data}"
-  cluster_security_group_id          = "${var.cluster_security_group_id}"
+  namespace                          = var.namespace
+  stage                              = var.stage
+  name                               = var.name
+  attributes                         = var.attributes
+  tags                               = var.tags
+  image_id                           = var.image_id
+  eks_worker_ami_name_filter         = var.eks_worker_ami_name_filter
+  instance_type                      = var.instance_type
+  vpc_id                             = module.vpc.vpc_id
+  subnet_ids                         = [module.subnets.public_subnet_ids]
+  health_check_type                  = var.health_check_type
+  min_size                           = var.min_size
+  max_size                           = var.max_size
+  wait_for_capacity_timeout          = var.wait_for_capacity_timeout
+  associate_public_ip_address        = var.associate_public_ip_address
+  cluster_name                       = var.cluster_name
+  cluster_endpoint                   = var.cluster_endpoint
+  cluster_certificate_authority_data = var.cluster_certificate_authority_data
+  cluster_security_group_id          = var.cluster_security_group_id
 
   # Auto-scaling policies and CloudWatch metric alarms
-  autoscaling_policies_enabled           = "${var.autoscaling_policies_enabled}"
-  cpu_utilization_high_threshold_percent = "${var.cpu_utilization_high_threshold_percent}"
-  cpu_utilization_low_threshold_percent  = "${var.cpu_utilization_low_threshold_percent}"
+  autoscaling_policies_enabled           = var.autoscaling_policies_enabled
+  cpu_utilization_high_threshold_percent = var.cpu_utilization_high_threshold_percent
+  cpu_utilization_low_threshold_percent  = var.cpu_utilization_low_threshold_percent
 }
 ```
 

--- a/README.yaml
+++ b/README.yaml
@@ -79,69 +79,69 @@ usage: |-
 
   ```hcl
   provider "aws" {
-    region = "${var.region}"
+    region = var.region
   }
 
   locals {
     # The usage of the specific kubernetes.io/cluster/* resource tags below are required
     # for EKS and Kubernetes to discover and manage networking resources
     # https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#base-vpc-networking
-    tags = "${merge(var.tags, map("kubernetes.io/cluster/${var.cluster_name}", "shared"))}"
+    tags = merge(var.tags, map("kubernetes.io/cluster/${var.cluster_name}", "shared"))
   }
 
   data "aws_availability_zones" "available" {}
 
   module "vpc" {
     source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
-    namespace  = "${var.namespace}"
-    stage      = "${var.stage}"
-    name       = "${var.name}"
-    attributes = "${var.attributes}"
-    tags       = "${local.tags}"
+    namespace  = var.namespace
+    stage      = var.stage
+    name       = var.name
+    attributes = var.attributes
+    tags       = local.tags
     cidr_block = "10.0.0.0/16"
   }
 
   module "subnets" {
     source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=master"
-    availability_zones  = ["${data.aws_availability_zones.available.names}"]
-    namespace           = "${var.namespace}"
-    stage               = "${var.stage}"
-    name                = "${var.name}"
-    attributes          = "${var.attributes}"
-    tags                = "${local.tags}"
-    region              = "${var.region}"
-    vpc_id              = "${module.vpc.vpc_id}"
-    igw_id              = "${module.vpc.igw_id}"
-    cidr_block          = "${module.vpc.vpc_cidr_block}"
+    availability_zones  = [data.aws_availability_zones.available.names]
+    namespace           = var.namespace
+    stage               = var.stage
+    name                = var.name
+    attributes          = var.attributes
+    tags                = local.tags
+    region              = var.region
+    vpc_id              = module.vpc.vpc_id
+    igw_id              = module.vpc.igw_id
+    cidr_block          = module.vpc.vpc_cidr_block
     nat_gateway_enabled = "true"
   }
 
   module "eks_workers" {
     source                             = "git::https://github.com/cloudposse/terraform-aws-eks-workers.git?ref=master"
-    namespace                          = "${var.namespace}"
-    stage                              = "${var.stage}"
-    name                               = "${var.name}"
-    attributes                         = "${var.attributes}"
-    tags                               = "${var.tags}"
-    image_id                           = "${var.image_id}"
-    eks_worker_ami_name_filter         = "${var.eks_worker_ami_name_filter}"
-    instance_type                      = "${var.instance_type}"
-    vpc_id                             = "${module.vpc.vpc_id}"
-    subnet_ids                         = ["${module.subnets.public_subnet_ids}"]
-    health_check_type                  = "${var.health_check_type}"
-    min_size                           = "${var.min_size}"
-    max_size                           = "${var.max_size}"
-    wait_for_capacity_timeout          = "${var.wait_for_capacity_timeout}"
-    associate_public_ip_address        = "${var.associate_public_ip_address}"
-    cluster_name                       = "${var.cluster_name}"
-    cluster_endpoint                   = "${var.cluster_endpoint}"
-    cluster_certificate_authority_data = "${var.cluster_certificate_authority_data}"
-    cluster_security_group_id          = "${var.cluster_security_group_id}"
+    namespace                          = var.namespace
+    stage                              = var.stage
+    name                               = var.name
+    attributes                         = var.attributes
+    tags                               = var.tags
+    image_id                           = var.image_id
+    eks_worker_ami_name_filter         = var.eks_worker_ami_name_filter
+    instance_type                      = var.instance_type
+    vpc_id                             = module.vpc.vpc_id
+    subnet_ids                         = [module.subnets.public_subnet_ids]
+    health_check_type                  = var.health_check_type
+    min_size                           = var.min_size
+    max_size                           = var.max_size
+    wait_for_capacity_timeout          = var.wait_for_capacity_timeout
+    associate_public_ip_address        = var.associate_public_ip_address
+    cluster_name                       = var.cluster_name
+    cluster_endpoint                   = var.cluster_endpoint
+    cluster_certificate_authority_data = var.cluster_certificate_authority_data
+    cluster_security_group_id          = var.cluster_security_group_id
 
     # Auto-scaling policies and CloudWatch metric alarms
-    autoscaling_policies_enabled           = "${var.autoscaling_policies_enabled}"
-    cpu_utilization_high_threshold_percent = "${var.cpu_utilization_high_threshold_percent}"
-    cpu_utilization_low_threshold_percent  = "${var.cpu_utilization_low_threshold_percent}"
+    autoscaling_policies_enabled           = var.autoscaling_policies_enabled
+    cpu_utilization_high_threshold_percent = var.cpu_utilization_high_threshold_percent
+    cpu_utilization_low_threshold_percent  = var.cpu_utilization_low_threshold_percent
   }
   ```
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,65 +1,65 @@
 provider "aws" {
-  region = "${var.region}"
+  region = var.region
 }
 
 locals {
   # The usage of the specific kubernetes.io/cluster/* resource tags below are required
   # for EKS and Kubernetes to discover and manage networking resources
   # https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#base-vpc-networking
-  tags = "${merge(var.tags, map("kubernetes.io/cluster/${var.cluster_name}", "shared"))}"
+  tags = merge(var.tags, map("kubernetes.io/cluster/${var.cluster_name}", "shared"))
 }
 
 data "aws_availability_zones" "available" {}
 
 module "vpc" {
   source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  attributes = "${var.attributes}"
-  tags       = "${local.tags}"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  attributes = var.attributes
+  tags       = local.tags
   cidr_block = "10.0.0.0/16"
 }
 
 module "subnets" {
   source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=master"
-  availability_zones  = ["${data.aws_availability_zones.available.names}"]
-  namespace           = "${var.namespace}"
-  stage               = "${var.stage}"
-  name                = "${var.name}"
-  attributes          = "${var.attributes}"
-  tags                = "${local.tags}"
-  region              = "${var.region}"
-  vpc_id              = "${module.vpc.vpc_id}"
-  igw_id              = "${module.vpc.igw_id}"
-  cidr_block          = "${module.vpc.vpc_cidr_block}"
+  availability_zones  = [data.aws_availability_zones.available.names]
+  namespace           = var.namespace
+  stage               = var.stage
+  name                = var.name
+  attributes          = var.attributes
+  tags                = local.tags
+  region              = var.region
+  vpc_id              = module.vpc.vpc_id
+  igw_id              = module.vpc.igw_id
+  cidr_block          = module.vpc.vpc_cidr_block
   nat_gateway_enabled = "true"
 }
 
 module "eks_workers" {
   source                             = "git::https://github.com/cloudposse/terraform-aws-eks-workers.git?ref=master"
-  namespace                          = "${var.namespace}"
-  stage                              = "${var.stage}"
-  name                               = "${var.name}"
-  attributes                         = "${var.attributes}"
-  tags                               = "${var.tags}"
-  image_id                           = "${var.image_id}"
-  eks_worker_ami_name_filter         = "${var.eks_worker_ami_name_filter}"
-  instance_type                      = "${var.instance_type}"
-  vpc_id                             = "${module.vpc.vpc_id}"
-  subnet_ids                         = ["${module.subnets.public_subnet_ids}"]
-  health_check_type                  = "${var.health_check_type}"
-  min_size                           = "${var.min_size}"
-  max_size                           = "${var.max_size}"
-  wait_for_capacity_timeout          = "${var.wait_for_capacity_timeout}"
-  associate_public_ip_address        = "${var.associate_public_ip_address}"
-  cluster_name                       = "${var.cluster_name}"
-  cluster_endpoint                   = "${var.cluster_endpoint}"
-  cluster_certificate_authority_data = "${var.cluster_certificate_authority_data}"
-  cluster_security_group_id          = "${var.cluster_security_group_id}"
+  namespace                          = var.namespace
+  stage                              = var.stage
+  name                               = var.name
+  attributes                         = var.attributes
+  tags                               = var.tags
+  image_id                           = var.image_id
+  eks_worker_ami_name_filter         = var.eks_worker_ami_name_filter
+  instance_type                      = var.instance_type
+  vpc_id                             = module.vpc.vpc_id
+  subnet_ids                         = [module.subnets.public_subnet_ids]
+  health_check_type                  = var.health_check_type
+  min_size                           = var.min_size
+  max_size                           = var.max_size
+  wait_for_capacity_timeout          = var.wait_for_capacity_timeout
+  associate_public_ip_address        = var.associate_public_ip_address
+  cluster_name                       = var.cluster_name
+  cluster_endpoint                   = var.cluster_endpoint
+  cluster_certificate_authority_data = var.cluster_certificate_authority_data
+  cluster_security_group_id          = var.cluster_security_group_id
 
   # Auto-scaling policies and CloudWatch metric alarms
-  autoscaling_policies_enabled           = "${var.autoscaling_policies_enabled}"
-  cpu_utilization_high_threshold_percent = "${var.cpu_utilization_high_threshold_percent}"
-  cpu_utilization_low_threshold_percent  = "${var.cpu_utilization_low_threshold_percent}"
+  autoscaling_policies_enabled           = var.autoscaling_policies_enabled
+  cpu_utilization_high_threshold_percent = var.cpu_utilization_high_threshold_percent
+  cpu_utilization_low_threshold_percent  = var.cpu_utilization_low_threshold_percent
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,74 +1,74 @@
 output "launch_template_id" {
   description = "ID of the launch template"
-  value       = "${module.eks_workers.launch_template_id}"
+  value       = module.eks_workers.launch_template_id
 }
 
 output "launch_template_arn" {
   description = "ARN of the launch template"
-  value       = "${module.eks_workers.launch_template_arn}"
+  value       = module.eks_workers.launch_template_arn
 }
 
 output "autoscaling_group_id" {
   description = "The AutoScaling Group ID"
-  value       = "${module.eks_workers.autoscaling_group_id}"
+  value       = module.eks_workers.autoscaling_group_id
 }
 
 output "autoscaling_group_name" {
   description = "The AutoScaling Group name"
-  value       = "${module.eks_workers.autoscaling_group_name}"
+  value       = module.eks_workers.autoscaling_group_name
 }
 
 output "autoscaling_group_arn" {
   description = "ARN of the AutoScaling Group"
-  value       = "${module.eks_workers.autoscaling_group_arn}"
+  value       = module.eks_workers.autoscaling_group_arn
 }
 
 output "autoscaling_group_min_size" {
   description = "The minimum size of the AutoScaling Group"
-  value       = "${module.eks_workers.autoscaling_group_min_size}"
+  value       = module.eks_workers.autoscaling_group_min_size
 }
 
 output "autoscaling_group_max_size" {
   description = "The maximum size of the AutoScaling Group"
-  value       = "${module.eks_workers.autoscaling_group_max_size}"
+  value       = module.eks_workers.autoscaling_group_max_size
 }
 
 output "autoscaling_group_desired_capacity" {
   description = "The number of Amazon EC2 instances that should be running in the group"
-  value       = "${module.eks_workers.autoscaling_group_desired_capacity}"
+  value       = module.eks_workers.autoscaling_group_desired_capacity
 }
 
 output "autoscaling_group_default_cooldown" {
   description = "Time between a scaling activity and the succeeding scaling activity"
-  value       = "${module.eks_workers.autoscaling_group_default_cooldown}"
+  value       = module.eks_workers.autoscaling_group_default_cooldown
 }
 
 output "autoscaling_group_health_check_grace_period" {
   description = "Time after instance comes into service before checking health"
-  value       = "${module.eks_workers.autoscaling_group_health_check_grace_period}"
+  value       = module.eks_workers.autoscaling_group_health_check_grace_period
 }
 
 output "autoscaling_group_health_check_type" {
   description = "`EC2` or `ELB`. Controls how health checking is done"
-  value       = "${module.eks_workers.autoscaling_group_health_check_type}"
+  value       = module.eks_workers.autoscaling_group_health_check_type
 }
 
 output "security_group_id" {
   description = "ID of the worker nodes Security Group"
-  value       = "${module.eks_workers.security_group_id}"
+  value       = module.eks_workers.security_group_id
 }
 
 output "security_group_arn" {
   description = "ARN of the worker nodes Security Group"
-  value       = "${module.eks_workers.security_group_arn}"
+  value       = module.eks_workers.security_group_arn
 }
 
 output "security_group_name" {
   description = "Name of the worker nodes Security Group"
-  value       = "${module.eks_workers.security_group_name}"
+  value       = module.eks_workers.security_group_name
 }
 
 output "config_map_aws_auth" {
   description = "Kubernetes ConfigMap configuration for worker nodes to join the EKS cluster. https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#required-kubernetes-configuration-to-join-worker-nodes"
-  value       = "${module.eks_workers.config_map_aws_auth}"
+  value       = module.eks_workers.config_map_aws_auth
 }

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  source     = "git::https://github.com/blackbookusa/terraform-terraform-label.git?ref=tags/0.2.1"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -141,7 +141,7 @@ data "aws_ami" "eks_worker" {
 }
 
 module "autoscale_group" {
-  source = "git::https://github.com/cloudposse/terraform-aws-ec2-autoscale-group.git?ref=tags/0.1.3"
+  source = "git::https://github.com/blackbookusa/terraform-aws-ec2-autoscale-group.git?ref=tags/0.1.3"
 
   enabled    = var.enabled
   namespace  = var.namespace

--- a/main.tf
+++ b/main.tf
@@ -1,20 +1,20 @@
 locals {
-  tags = "${merge(var.tags, map("kubernetes.io/cluster/${var.cluster_name}", "owned"))}"
+  tags = merge(var.tags, map("kubernetes.io/cluster/${var.cluster_name}", "owned"))
 }
 
 module "label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  delimiter  = "${var.delimiter}"
-  attributes = ["${compact(concat(var.attributes, list("workers")))}"]
-  tags       = "${local.tags}"
-  enabled    = "${var.enabled}"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  delimiter  = var.delimiter
+  attributes = [compact(concat(var.attributes, list("workers")))]
+  tags       = local.tags
+  enabled    = var.enabled
 }
 
 data "aws_iam_policy_document" "assume_role" {
-  count = "${var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0}"
+  count = var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0
 
   statement {
     effect  = "Allow"
@@ -28,113 +28,113 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "default" {
-  count              = "${var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0}"
-  name               = "${module.label.id}"
-  assume_role_policy = "${join("", data.aws_iam_policy_document.assume_role.*.json)}"
+  count              = var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0
+  name               = module.label.id
+  assume_role_policy = join("", data.aws_iam_policy_document.assume_role.*.json)
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_worker_node_policy" {
-  count      = "${var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0}"
+  count      = var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
-  role       = "${join("", aws_iam_role.default.*.name)}"
+  role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_cni_policy" {
-  count      = "${var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0}"
+  count      = var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
-  role       = "${join("", aws_iam_role.default.*.name)}"
+  role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_ec2_container_registry_read_only" {
-  count      = "${var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0}"
+  count      = var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
-  role       = "${join("", aws_iam_role.default.*.name)}"
+  role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_iam_role_policy_attachment" "existing_policies_attach_to_eks_workers_role" {
-  count      = "${var.enabled == "true" && var.use_existing_aws_iam_instance_profile== "false" ? var.workers_role_policy_arns_count : 0}"
-  policy_arn = "${element(var.workers_role_policy_arns, count.index)}"
-  role       = "${join("", aws_iam_role.default.*.name)}"
+  count      = var.enabled == "true" && var.use_existing_aws_iam_instance_profile== "false" ? var.workers_role_policy_arns_count : 0
+  policy_arn = var.workers_role_policy_arns[count.index]
+  role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_iam_instance_profile" "default" {
-  count = "${var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0}"
-  name  = "${module.label.id}"
-  role  = "${join("", aws_iam_role.default.*.name)}"
+  count = var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0
+  name  = module.label.id
+  role  = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_security_group" "default" {
-  count       = "${var.enabled == "true" && var.use_existing_security_group == "false" ? 1 : 0}"
-  name        = "${module.label.id}"
+  count       = var.enabled == "true" && var.use_existing_security_group == "false" ? 1 : 0
+  name        = module.label.id
   description = "Security Group for EKS worker nodes"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${module.label.tags}"
+  vpc_id      = var.vpc_id
+  tags        = module.label.tags
 }
 
 resource "aws_security_group_rule" "egress" {
-  count             = "${var.enabled == "true" && var.use_existing_security_group == "false" ? 1 : 0}"
+  count             = var.enabled == "true" && var.use_existing_security_group == "false" ? 1 : 0
   description       = "Allow all egress traffic"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${join("", aws_security_group.default.*.id)}"
+  security_group_id = join("", aws_security_group.default.*.id)
   type              = "egress"
 }
 
 resource "aws_security_group_rule" "ingress_self" {
-  count                    = "${var.enabled == "true" && var.use_existing_security_group == "false" ? 1 : 0}"
+  count                    = var.enabled == "true" && var.use_existing_security_group == "false" ? 1 : 0
   description              = "Allow nodes to communicate with each other"
   from_port                = 0
   to_port                  = 65535
   protocol                 = "-1"
-  security_group_id        = "${join("", aws_security_group.default.*.id)}"
-  source_security_group_id = "${join("", aws_security_group.default.*.id)}"
+  security_group_id        = join("", aws_security_group.default.*.id)
+  source_security_group_id = join("", aws_security_group.default.*.id)
   type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "ingress_cluster" {
-  count                    = "${var.enabled == "true" && var.use_existing_security_group == "false" ? 1 : 0}"
+  count                    = var.enabled == "true" && var.use_existing_security_group == "false" ? 1 : 0
   description              = "Allow worker kubelets and pods to receive communication from the cluster control plane"
   from_port                = 0
   to_port                  = 65535
   protocol                 = "-1"
-  security_group_id        = "${join("", aws_security_group.default.*.id)}"
-  source_security_group_id = "${var.cluster_security_group_id}"
+  security_group_id        = join("", aws_security_group.default.*.id)
+  source_security_group_id = var.cluster_security_group_id
   type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "ingress_security_groups" {
-  count                    = "${var.enabled == "true" && var.use_existing_security_group == "false" ? length(var.allowed_security_groups) : 0}"
+  count                    = var.enabled == "true" && var.use_existing_security_group == "false" ? length(var.allowed_security_groups) : 0
   description              = "Allow inbound traffic from existing Security Groups"
   from_port                = 0
   to_port                  = 65535
   protocol                 = "-1"
-  source_security_group_id = "${element(var.allowed_security_groups, count.index)}"
-  security_group_id        = "${join("", aws_security_group.default.*.id)}"
+  source_security_group_id = var.allowed_security_groups[count.index]
+  security_group_id        = join("", aws_security_group.default.*.id)
   type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "ingress_cidr_blocks" {
-  count             = "${var.enabled == "true" && length(var.allowed_cidr_blocks) > 0 && var.use_existing_security_group == "false" ? 1 : 0}"
+  count             = var.enabled == "true" && length(var.allowed_cidr_blocks) > 0 && var.use_existing_security_group == "false" ? 1 : 0
   description       = "Allow inbound traffic from CIDR blocks"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
-  cidr_blocks       = ["${var.allowed_cidr_blocks}"]
-  security_group_id = "${join("", aws_security_group.default.*.id)}"
+  cidr_blocks       = [var.allowed_cidr_blocks]
+  security_group_id = join("", aws_security_group.default.*.id)
   type              = "ingress"
 }
 
 data "aws_ami" "eks_worker" {
-  count = "${var.enabled == "true" && var.use_custom_image_id == "false" ? 1 : 0}"
+  count = var.enabled == "true" && var.use_custom_image_id == "false" ? 1 : 0
 
   most_recent = true
-  name_regex  = "${var.eks_worker_ami_name_regex}"
+  name_regex  = var.eks_worker_ami_name_regex
 
   filter {
     name   = "name"
-    values = ["${var.eks_worker_ami_name_filter}"]
+    values = [var.eks_worker_ami_name_filter]
   }
 
   owners = ["602401143452"] # Amazon
@@ -143,91 +143,91 @@ data "aws_ami" "eks_worker" {
 module "autoscale_group" {
   source = "git::https://github.com/cloudposse/terraform-aws-ec2-autoscale-group.git?ref=tags/0.1.3"
 
-  enabled    = "${var.enabled}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  delimiter  = "${var.delimiter}"
-  attributes = "${var.attributes}"
+  enabled    = var.enabled
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  delimiter  = var.delimiter
+  attributes = var.attributes
 
-  image_id                  = "${var.use_custom_image_id == "true" ? var.image_id : join("", data.aws_ami.eks_worker.*.id)}"
-  iam_instance_profile_name = "${var.use_existing_aws_iam_instance_profile == "false" ? join("", aws_iam_instance_profile.default.*.name) : var.aws_iam_instance_profile_name}"
-  security_group_ids        = ["${compact(concat(list(var.use_existing_security_group == "false" ? join("", aws_security_group.default.*.id) : var.workers_security_group_id), var.additional_security_group_ids))}"]
-  user_data_base64          = "${base64encode(join("", data.template_file.userdata.*.rendered))}"
-  tags                      = "${module.label.tags}"
+  image_id                  = var.use_custom_image_id == "true" ? var.image_id : join("", data.aws_ami.eks_worker.*.id)
+  iam_instance_profile_name = var.use_existing_aws_iam_instance_profile == "false" ? join("", aws_iam_instance_profile.default.*.name) : var.aws_iam_instance_profile_name
+  security_group_ids        = [compact(concat(list(var.use_existing_security_group == "false" ? join("", aws_security_group.default.*.id) : var.workers_security_group_id), var.additional_security_group_ids))]
+  user_data_base64          = base64encode(join("", data.template_file.userdata.*.rendered))
+  tags                      = module.label.tags
 
-  instance_type                           = "${var.instance_type}"
-  subnet_ids                              = ["${var.subnet_ids}"]
-  min_size                                = "${var.min_size}"
-  max_size                                = "${var.max_size}"
-  associate_public_ip_address             = "${var.associate_public_ip_address}"
-  block_device_mappings                   = ["${var.block_device_mappings}"]
-  credit_specification                    = ["${var.credit_specification}"]
-  disable_api_termination                 = "${var.disable_api_termination}"
-  ebs_optimized                           = "${var.ebs_optimized}"
-  elastic_gpu_specifications              = ["${var.elastic_gpu_specifications}"]
-  instance_initiated_shutdown_behavior    = "${var.instance_initiated_shutdown_behavior}"
-  instance_market_options                 = ["${var.instance_market_options }"]
-  key_name                                = "${var.key_name}"
-  placement                               = ["${var.placement}"]
-  enable_monitoring                       = "${var.enable_monitoring}"
-  load_balancers                          = ["${var.load_balancers}"]
-  health_check_grace_period               = "${var.health_check_grace_period}"
-  health_check_type                       = "${var.health_check_type}"
-  min_elb_capacity                        = "${var.min_elb_capacity}"
-  wait_for_elb_capacity                   = "${var.wait_for_elb_capacity}"
-  target_group_arns                       = ["${var.target_group_arns}"]
-  default_cooldown                        = "${var.default_cooldown}"
-  force_delete                            = "${var.force_delete}"
-  termination_policies                    = "${var.termination_policies}"
-  suspended_processes                     = "${var.suspended_processes}"
-  placement_group                         = "${var.placement_group}"
-  enabled_metrics                         = ["${var.enabled_metrics}"]
-  metrics_granularity                     = "${var.metrics_granularity}"
-  wait_for_capacity_timeout               = "${var.wait_for_capacity_timeout}"
-  protect_from_scale_in                   = "${var.protect_from_scale_in}"
-  service_linked_role_arn                 = "${var.service_linked_role_arn}"
-  autoscaling_policies_enabled            = "${var.autoscaling_policies_enabled}"
-  scale_up_cooldown_seconds               = "${var.scale_up_cooldown_seconds}"
-  scale_up_scaling_adjustment             = "${var.scale_up_scaling_adjustment}"
-  scale_up_adjustment_type                = "${var.scale_up_adjustment_type}"
-  scale_up_policy_type                    = "${var.scale_up_policy_type}"
-  scale_down_cooldown_seconds             = "${var.scale_down_cooldown_seconds}"
-  scale_down_scaling_adjustment           = "${var.scale_down_scaling_adjustment}"
-  scale_down_adjustment_type              = "${var.scale_down_adjustment_type}"
-  scale_down_policy_type                  = "${var.scale_down_policy_type}"
-  cpu_utilization_high_evaluation_periods = "${var.cpu_utilization_high_evaluation_periods}"
-  cpu_utilization_high_period_seconds     = "${var.cpu_utilization_high_period_seconds}"
-  cpu_utilization_high_threshold_percent  = "${var.cpu_utilization_high_threshold_percent}"
-  cpu_utilization_high_statistic          = "${var.cpu_utilization_high_statistic}"
-  cpu_utilization_low_evaluation_periods  = "${var.cpu_utilization_low_evaluation_periods}"
-  cpu_utilization_low_period_seconds      = "${var.cpu_utilization_low_period_seconds}"
-  cpu_utilization_low_statistic           = "${var.cpu_utilization_low_statistic}"
-  cpu_utilization_low_threshold_percent   = "${var.cpu_utilization_low_threshold_percent}"
+  instance_type                           = var.instance_type
+  subnet_ids                              = [var.subnet_ids]
+  min_size                                = var.min_size
+  max_size                                = var.max_size
+  associate_public_ip_address             = var.associate_public_ip_address
+  block_device_mappings                   = [var.block_device_mappings]
+  credit_specification                    = [var.credit_specification]
+  disable_api_termination                 = var.disable_api_termination
+  ebs_optimized                           = var.ebs_optimized
+  elastic_gpu_specifications              = [var.elastic_gpu_specifications]
+  instance_initiated_shutdown_behavior    = var.instance_initiated_shutdown_behavior
+  instance_market_options                 = [var.instance_market_options]
+  key_name                                = var.key_name
+  placement                               = [var.placement]
+  enable_monitoring                       = var.enable_monitoring
+  load_balancers                          = [var.load_balancers]
+  health_check_grace_period               = var.health_check_grace_period
+  health_check_type                       = var.health_check_type
+  min_elb_capacity                        = var.min_elb_capacity
+  wait_for_elb_capacity                   = var.wait_for_elb_capacity
+  target_group_arns                       = [var.target_group_arns]
+  default_cooldown                        = var.default_cooldown
+  force_delete                            = var.force_delete
+  termination_policies                    = var.termination_policies
+  suspended_processes                     = var.suspended_processes
+  placement_group                         = var.placement_group
+  enabled_metrics                         = [var.enabled_metrics]
+  metrics_granularity                     = var.metrics_granularity
+  wait_for_capacity_timeout               = var.wait_for_capacity_timeout
+  protect_from_scale_in                   = var.protect_from_scale_in
+  service_linked_role_arn                 = var.service_linked_role_arn
+  autoscaling_policies_enabled            = var.autoscaling_policies_enabled
+  scale_up_cooldown_seconds               = var.scale_up_cooldown_seconds
+  scale_up_scaling_adjustment             = var.scale_up_scaling_adjustment
+  scale_up_adjustment_type                = var.scale_up_adjustment_type
+  scale_up_policy_type                    = var.scale_up_policy_type
+  scale_down_cooldown_seconds             = var.scale_down_cooldown_seconds
+  scale_down_scaling_adjustment           = var.scale_down_scaling_adjustment
+  scale_down_adjustment_type              = var.scale_down_adjustment_type
+  scale_down_policy_type                  = var.scale_down_policy_type
+  cpu_utilization_high_evaluation_periods = var.cpu_utilization_high_evaluation_periods
+  cpu_utilization_high_period_seconds     = var.cpu_utilization_high_period_seconds
+  cpu_utilization_high_threshold_percent  = var.cpu_utilization_high_threshold_percent
+  cpu_utilization_high_statistic          = var.cpu_utilization_high_statistic
+  cpu_utilization_low_evaluation_periods  = var.cpu_utilization_low_evaluation_periods
+  cpu_utilization_low_period_seconds      = var.cpu_utilization_low_period_seconds
+  cpu_utilization_low_statistic           = var.cpu_utilization_low_statistic
+  cpu_utilization_low_threshold_percent   = var.cpu_utilization_low_threshold_percent
 }
 
 data "template_file" "userdata" {
-  count    = "${var.enabled == "true" ? 1 : 0}"
-  template = "${file("${path.module}/userdata.tpl")}"
+  count    = var.enabled == "true" ? 1 : 0
+  template = file("${path.module}/userdata.tpl")
 
   vars {
-    cluster_endpoint           = "${var.cluster_endpoint}"
-    certificate_authority_data = "${var.cluster_certificate_authority_data}"
-    cluster_name               = "${var.cluster_name}"
-    bootstrap_extra_args       = "${var.bootstrap_extra_args}"
+    cluster_endpoint           = var.cluster_endpoint
+    certificate_authority_data = var.cluster_certificate_authority_data
+    cluster_name               = var.cluster_name
+    bootstrap_extra_args       = var.bootstrap_extra_args
   }
 }
 
 data "aws_iam_instance_profile" "default" {
-  count = "${var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "true" ? 1 : 0}"
-  name  = "${var.aws_iam_instance_profile_name}"
+  count = var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "true" ? 1 : 0
+  name  = var.aws_iam_instance_profile_name
 }
 
 data "template_file" "config_map_aws_auth" {
-  count    = "${var.enabled == "true" ? 1 : 0}"
-  template = "${file("${path.module}/config_map_aws_auth.tpl")}"
+  count    = var.enabled == "true" ? 1 : 0
+  template = file("${path.module}/config_map_aws_auth.tpl")
 
   vars {
-    aws_iam_role_arn = "${var.use_existing_aws_iam_instance_profile == "true" ?  join("", data.aws_iam_instance_profile.default.*.role_arn) : join("", aws_iam_role.default.*.arn)}"
+    aws_iam_role_arn = var.use_existing_aws_iam_instance_profile == "true" ?  join("", data.aws_iam_instance_profile.default.*.role_arn) : join("", aws_iam_role.default.*.arn)
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,84 +1,84 @@
 output "launch_template_id" {
   description = "The ID of the launch template"
-  value       = "${module.autoscale_group.launch_template_id}"
+  value       = module.autoscale_group.launch_template_id
 }
 
 output "launch_template_arn" {
   description = "ARN of the launch template"
-  value       = "${module.autoscale_group.launch_template_arn}"
+  value       = module.autoscale_group.launch_template_arn
 }
 
 output "autoscaling_group_id" {
   description = "The AutoScaling Group ID"
-  value       = "${module.autoscale_group.autoscaling_group_id}"
+  value       = module.autoscale_group.autoscaling_group_id
 }
 
 output "autoscaling_group_name" {
   description = "The AutoScaling Group name"
-  value       = "${module.autoscale_group.autoscaling_group_name}"
+  value       = module.autoscale_group.autoscaling_group_name
 }
 
 output "autoscaling_group_arn" {
   description = "ARN of the AutoScaling Group"
-  value       = "${module.autoscale_group.autoscaling_group_arn}"
+  value       = module.autoscale_group.autoscaling_group_arn
 }
 
 output "autoscaling_group_min_size" {
   description = "The minimum size of the AutoScaling Group"
-  value       = "${module.autoscale_group.autoscaling_group_min_size}"
+  value       = module.autoscale_group.autoscaling_group_min_size
 }
 
 output "autoscaling_group_max_size" {
   description = "The maximum size of the AutoScaling Group"
-  value       = "${module.autoscale_group.autoscaling_group_max_size}"
+  value       = module.autoscale_group.autoscaling_group_max_size
 }
 
 output "autoscaling_group_desired_capacity" {
   description = "The number of Amazon EC2 instances that should be running in the group"
-  value       = "${module.autoscale_group.autoscaling_group_desired_capacity}"
+  value       = module.autoscale_group.autoscaling_group_desired_capacity
 }
 
 output "autoscaling_group_default_cooldown" {
   description = "Time between a scaling activity and the succeeding scaling activity"
-  value       = "${module.autoscale_group.autoscaling_group_default_cooldown}"
+  value       = module.autoscale_group.autoscaling_group_default_cooldown
 }
 
 output "autoscaling_group_health_check_grace_period" {
   description = "Time after instance comes into service before checking health"
-  value       = "${module.autoscale_group.autoscaling_group_health_check_grace_period}"
+  value       = module.autoscale_group.autoscaling_group_health_check_grace_period
 }
 
 output "autoscaling_group_health_check_type" {
   description = "`EC2` or `ELB`. Controls how health checking is done"
-  value       = "${module.autoscale_group.autoscaling_group_health_check_type}"
+  value       = module.autoscale_group.autoscaling_group_health_check_type
 }
 
 output "security_group_id" {
   description = "ID of the worker nodes Security Group"
-  value       = "${join("", aws_security_group.default.*.id)}"
+  value       = join("", aws_security_group.default.*.id)
 }
 
 output "security_group_arn" {
   description = "ARN of the worker nodes Security Group"
-  value       = "${join("", aws_security_group.default.*.arn)}"
+  value       = join("", aws_security_group.default.*.arn)
 }
 
 output "security_group_name" {
   description = "Name of the worker nodes Security Group"
-  value       = "${join("", aws_security_group.default.*.name)}"
+  value       = join("", aws_security_group.default.*.name)
 }
 
 output "worker_role_arn" {
   description = "ARN of the worker nodes IAM role"
-  value       = "${join("", aws_iam_role.default.*.arn)}"
+  value       = join("", aws_iam_role.default.*.arn)
 }
 
 output "worker_role_name" {
   description = "Name of the worker nodes IAM role"
-  value       = "${join("", aws_iam_role.default.*.name)}"
+  value       = join("", aws_iam_role.default.*.name)
 }
 
 output "config_map_aws_auth" {
   description = "Kubernetes ConfigMap configuration for worker nodes to join the EKS cluster. https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#required-kubernetes-configuration-to-join-worker-nodes"
-  value       = "${join("", data.template_file.config_map_aws_auth.*.rendered)}"
+  value       = join("", data.template_file.config_map_aws_auth.*.rendered)
 }


### PR DESCRIPTION
removes a lot of the interpolation and refactors `element` functions to list indexing

e.g. `element(var.workers_role_policy_arns, count.index)` to `var.workers_role_policy_arns[count.index]`