### PR TITLE
Terraform 0.12 upgrade

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,26 +1,31 @@
 locals {
-  tags = "${merge(var.tags, map("kubernetes.io/cluster/${var.cluster_name}", "owned"))}"
+  tags = merge(
+    var.tags,
+    {
+      "kubernetes.io/cluster/${var.cluster_name}" = "owned"
+    },
+  )
 }
 
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  delimiter  = "${var.delimiter}"
-  attributes = ["${compact(concat(var.attributes, list("workers")))}"]
-  tags       = "${local.tags}"
-  enabled    = "${var.enabled}"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.4.0"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  delimiter  = var.delimiter
+  attributes = compact(concat(var.attributes, ["workers"]))
+  tags       = local.tags
+  enabled    = var.enabled
 }
 
 data "aws_iam_policy_document" "assume_role" {
-  count = "${var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0}"
+  count = var.enabled && var.aws_iam_instance_profile_name == null ? 1 : 0
 
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["ec2.amazonaws.com"]
     }
@@ -28,206 +33,214 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "default" {
-  count              = "${var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0}"
-  name               = "${module.label.id}"
-  assume_role_policy = "${join("", data.aws_iam_policy_document.assume_role.*.json)}"
+  count              = var.enabled && var.aws_iam_instance_profile_name == null ? 1 : 0
+  name               = module.label.id
+  assume_role_policy = join("", data.aws_iam_policy_document.assume_role.*.json)
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_worker_node_policy" {
-  count      = "${var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0}"
+  count      = var.enabled && var.aws_iam_instance_profile_name == null ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
-  role       = "${join("", aws_iam_role.default.*.name)}"
+  role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_cni_policy" {
-  count      = "${var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0}"
+  count      = var.enabled && var.aws_iam_instance_profile_name == null ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
-  role       = "${join("", aws_iam_role.default.*.name)}"
+  role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_ec2_container_registry_read_only" {
-  count      = "${var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0}"
+  count      = var.enabled && var.aws_iam_instance_profile_name == null ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
-  role       = "${join("", aws_iam_role.default.*.name)}"
+  role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_iam_role_policy_attachment" "existing_policies_attach_to_eks_workers_role" {
-  count      = "${var.enabled == "true" && var.use_existing_aws_iam_instance_profile== "false" ? var.workers_role_policy_arns_count : 0}"
-  policy_arn = "${element(var.workers_role_policy_arns, count.index)}"
-  role       = "${join("", aws_iam_role.default.*.name)}"
+  count      = var.enabled && var.aws_iam_instance_profile_name == null ? 1 : 0
+  policy_arn = element(var.workers_role_policy_arns, count.index)
+  role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_iam_instance_profile" "default" {
-  count = "${var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "false" ? 1 : 0}"
-  name  = "${module.label.id}"
-  role  = "${join("", aws_iam_role.default.*.name)}"
+  count = var.enabled && var.aws_iam_instance_profile_name == null ? 1 : 0
+  name  = module.label.id
+  role  = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_security_group" "default" {
-  count       = "${var.enabled == "true" && var.use_existing_security_group == "false" ? 1 : 0}"
-  name        = "${module.label.id}"
+  count       = var.enabled && var.workers_security_group_id == null ? 1 : 0
+  name        = module.label.id
   description = "Security Group for EKS worker nodes"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${module.label.tags}"
+  vpc_id      = var.vpc_id
+  tags        = module.label.tags
 }
 
 resource "aws_security_group_rule" "egress" {
-  count             = "${var.enabled == "true" && var.use_existing_security_group == "false" ? 1 : 0}"
+  count             = var.enabled && var.workers_security_group_id == null ? 1 : 0
   description       = "Allow all egress traffic"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${join("", aws_security_group.default.*.id)}"
+  security_group_id = join("", aws_security_group.default.*.id)
   type              = "egress"
 }
 
 resource "aws_security_group_rule" "ingress_self" {
-  count                    = "${var.enabled == "true" && var.use_existing_security_group == "false" ? 1 : 0}"
+  count                    = var.enabled && var.workers_security_group_id == null ? 1 : 0
   description              = "Allow nodes to communicate with each other"
   from_port                = 0
   to_port                  = 65535
   protocol                 = "-1"
-  security_group_id        = "${join("", aws_security_group.default.*.id)}"
-  source_security_group_id = "${join("", aws_security_group.default.*.id)}"
+  security_group_id        = join("", aws_security_group.default.*.id)
+  source_security_group_id = join("", aws_security_group.default.*.id)
   type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "ingress_cluster" {
-  count                    = "${var.enabled == "true" && var.use_existing_security_group == "false" ? 1 : 0}"
+  count                    = var.enabled && var.workers_security_group_id == null ? 1 : 0
   description              = "Allow worker kubelets and pods to receive communication from the cluster control plane"
   from_port                = 0
   to_port                  = 65535
   protocol                 = "-1"
-  security_group_id        = "${join("", aws_security_group.default.*.id)}"
-  source_security_group_id = "${var.cluster_security_group_id}"
+  security_group_id        = join("", aws_security_group.default.*.id)
+  source_security_group_id = var.cluster_security_group_id
   type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "ingress_security_groups" {
-  count                    = "${var.enabled == "true" && var.use_existing_security_group == "false" ? length(var.allowed_security_groups) : 0}"
+  count                    = var.enabled && var.workers_security_group_id == null ? length(var.allowed_security_groups) : 0
   description              = "Allow inbound traffic from existing Security Groups"
   from_port                = 0
   to_port                  = 65535
   protocol                 = "-1"
-  source_security_group_id = "${element(var.allowed_security_groups, count.index)}"
-  security_group_id        = "${join("", aws_security_group.default.*.id)}"
+  source_security_group_id = element(var.allowed_security_groups, count.index)
+  security_group_id        = join("", aws_security_group.default.*.id)
   type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "ingress_cidr_blocks" {
-  count             = "${var.enabled == "true" && length(var.allowed_cidr_blocks) > 0 && var.use_existing_security_group == "false" ? 1 : 0}"
+  count             = var.enabled && var.workers_security_group_id == null ? 1 : 0
   description       = "Allow inbound traffic from CIDR blocks"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
-  cidr_blocks       = ["${var.allowed_cidr_blocks}"]
-  security_group_id = "${join("", aws_security_group.default.*.id)}"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = join("", aws_security_group.default.*.id)
   type              = "ingress"
 }
 
 data "aws_ami" "eks_worker" {
-  count = "${var.enabled == "true" && var.use_custom_image_id == "false" ? 1 : 0}"
+  count = var.enabled && var.image_id == null ? 1 : 0
 
   most_recent = true
-  name_regex  = "${var.eks_worker_ami_name_regex}"
+  name_regex  = var.eks_worker_ami_name_regex
 
   filter {
     name   = "name"
-    values = ["${var.eks_worker_ami_name_filter}"]
+    values = [var.eks_worker_ami_name_filter]
   }
 
   owners = ["602401143452"] # Amazon
 }
 
 module "autoscale_group" {
-  source = "git::https://github.com/cloudposse/terraform-aws-ec2-autoscale-group.git?ref=tags/0.1.3"
+  source = "git::https://github.com/cloudposse/terraform-aws-ec2-autoscale-group.git?ref=tags/0.2.0"
 
-  enabled    = "${var.enabled}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  delimiter  = "${var.delimiter}"
-  attributes = "${var.attributes}"
+  enabled    = var.enabled
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  delimiter  = var.delimiter
+  attributes = var.attributes
 
-  image_id                  = "${var.use_custom_image_id == "true" ? var.image_id : join("", data.aws_ami.eks_worker.*.id)}"
-  iam_instance_profile_name = "${var.use_existing_aws_iam_instance_profile == "false" ? join("", aws_iam_instance_profile.default.*.name) : var.aws_iam_instance_profile_name}"
-  security_group_ids        = ["${compact(concat(list(var.use_existing_security_group == "false" ? join("", aws_security_group.default.*.id) : var.workers_security_group_id), var.additional_security_group_ids))}"]
-  user_data_base64          = "${base64encode(join("", data.template_file.userdata.*.rendered))}"
-  tags                      = "${module.label.tags}"
+  image_id                  = var.image_id != null ? var.image_id : join("", data.aws_ami.eks_worker.*.id)
+  iam_instance_profile_name = var.aws_iam_instance_profile_name == null ? join("", aws_iam_instance_profile.default.*.name) : var.aws_iam_instance_profile_name
+  security_group_ids = compact(
+    concat(
+      [
+        var.workers_security_group_id == null ? join("", aws_security_group.default.*.id) : var.workers_security_group_id,
+      ],
+      var.additional_security_group_ids,
+    ),
+  )
+  user_data_base64 = base64encode(join("", data.template_file.userdata.*.rendered))
+  tags             = module.label.tags
 
-  instance_type                           = "${var.instance_type}"
-  subnet_ids                              = ["${var.subnet_ids}"]
-  min_size                                = "${var.min_size}"
-  max_size                                = "${var.max_size}"
-  associate_public_ip_address             = "${var.associate_public_ip_address}"
-  block_device_mappings                   = ["${var.block_device_mappings}"]
-  credit_specification                    = ["${var.credit_specification}"]
-  disable_api_termination                 = "${var.disable_api_termination}"
-  ebs_optimized                           = "${var.ebs_optimized}"
-  elastic_gpu_specifications              = ["${var.elastic_gpu_specifications}"]
-  instance_initiated_shutdown_behavior    = "${var.instance_initiated_shutdown_behavior}"
-  instance_market_options                 = ["${var.instance_market_options }"]
-  key_name                                = "${var.key_name}"
-  placement                               = ["${var.placement}"]
-  enable_monitoring                       = "${var.enable_monitoring}"
-  load_balancers                          = ["${var.load_balancers}"]
-  health_check_grace_period               = "${var.health_check_grace_period}"
-  health_check_type                       = "${var.health_check_type}"
-  min_elb_capacity                        = "${var.min_elb_capacity}"
-  wait_for_elb_capacity                   = "${var.wait_for_elb_capacity}"
-  target_group_arns                       = ["${var.target_group_arns}"]
-  default_cooldown                        = "${var.default_cooldown}"
-  force_delete                            = "${var.force_delete}"
-  termination_policies                    = "${var.termination_policies}"
-  suspended_processes                     = "${var.suspended_processes}"
-  placement_group                         = "${var.placement_group}"
-  enabled_metrics                         = ["${var.enabled_metrics}"]
-  metrics_granularity                     = "${var.metrics_granularity}"
-  wait_for_capacity_timeout               = "${var.wait_for_capacity_timeout}"
-  protect_from_scale_in                   = "${var.protect_from_scale_in}"
-  service_linked_role_arn                 = "${var.service_linked_role_arn}"
-  autoscaling_policies_enabled            = "${var.autoscaling_policies_enabled}"
-  scale_up_cooldown_seconds               = "${var.scale_up_cooldown_seconds}"
-  scale_up_scaling_adjustment             = "${var.scale_up_scaling_adjustment}"
-  scale_up_adjustment_type                = "${var.scale_up_adjustment_type}"
-  scale_up_policy_type                    = "${var.scale_up_policy_type}"
-  scale_down_cooldown_seconds             = "${var.scale_down_cooldown_seconds}"
-  scale_down_scaling_adjustment           = "${var.scale_down_scaling_adjustment}"
-  scale_down_adjustment_type              = "${var.scale_down_adjustment_type}"
-  scale_down_policy_type                  = "${var.scale_down_policy_type}"
-  cpu_utilization_high_evaluation_periods = "${var.cpu_utilization_high_evaluation_periods}"
-  cpu_utilization_high_period_seconds     = "${var.cpu_utilization_high_period_seconds}"
-  cpu_utilization_high_threshold_percent  = "${var.cpu_utilization_high_threshold_percent}"
-  cpu_utilization_high_statistic          = "${var.cpu_utilization_high_statistic}"
-  cpu_utilization_low_evaluation_periods  = "${var.cpu_utilization_low_evaluation_periods}"
-  cpu_utilization_low_period_seconds      = "${var.cpu_utilization_low_period_seconds}"
-  cpu_utilization_low_statistic           = "${var.cpu_utilization_low_statistic}"
-  cpu_utilization_low_threshold_percent   = "${var.cpu_utilization_low_threshold_percent}"
+  instance_type                           = var.instance_type
+  subnet_ids                              = var.subnet_ids
+  min_size                                = var.min_size
+  max_size                                = var.max_size
+  associate_public_ip_address             = var.associate_public_ip_address
+  block_device_mappings                   = var.block_device_mappings
+  credit_specification                    = var.credit_specification
+  disable_api_termination                 = var.disable_api_termination
+  ebs_optimized                           = var.ebs_optimized
+  elastic_gpu_specifications              = var.elastic_gpu_specifications
+  instance_initiated_shutdown_behavior    = var.instance_initiated_shutdown_behavior
+  instance_market_options                 = var.instance_market_options
+  key_name                                = var.key_name
+  placement                               = var.placement
+  enable_monitoring                       = var.enable_monitoring
+  load_balancers                          = var.load_balancers
+  health_check_grace_period               = var.health_check_grace_period
+  health_check_type                       = var.health_check_type
+  min_elb_capacity                        = var.min_elb_capacity
+  wait_for_elb_capacity                   = var.wait_for_elb_capacity
+  target_group_arns                       = var.target_group_arns
+  default_cooldown                        = var.default_cooldown
+  force_delete                            = var.force_delete
+  termination_policies                    = var.termination_policies
+  suspended_processes                     = var.suspended_processes
+  placement_group                         = var.placement_group
+  enabled_metrics                         = var.enabled_metrics
+  metrics_granularity                     = var.metrics_granularity
+  wait_for_capacity_timeout               = var.wait_for_capacity_timeout
+  protect_from_scale_in                   = var.protect_from_scale_in
+  service_linked_role_arn                 = var.service_linked_role_arn
+  autoscaling_policies_enabled            = var.autoscaling_policies_enabled
+  scale_up_cooldown_seconds               = var.scale_up_cooldown_seconds
+  scale_up_scaling_adjustment             = var.scale_up_scaling_adjustment
+  scale_up_adjustment_type                = var.scale_up_adjustment_type
+  scale_up_policy_type                    = var.scale_up_policy_type
+  scale_down_cooldown_seconds             = var.scale_down_cooldown_seconds
+  scale_down_scaling_adjustment           = var.scale_down_scaling_adjustment
+  scale_down_adjustment_type              = var.scale_down_adjustment_type
+  scale_down_policy_type                  = var.scale_down_policy_type
+  cpu_utilization_high_evaluation_periods = var.cpu_utilization_high_evaluation_periods
+  cpu_utilization_high_period_seconds     = var.cpu_utilization_high_period_seconds
+  cpu_utilization_high_threshold_percent  = var.cpu_utilization_high_threshold_percent
+  cpu_utilization_high_statistic          = var.cpu_utilization_high_statistic
+  cpu_utilization_low_evaluation_periods  = var.cpu_utilization_low_evaluation_periods
+  cpu_utilization_low_period_seconds      = var.cpu_utilization_low_period_seconds
+  cpu_utilization_low_statistic           = var.cpu_utilization_low_statistic
+  cpu_utilization_low_threshold_percent   = var.cpu_utilization_low_threshold_percent
 }
 
 data "template_file" "userdata" {
-  count    = "${var.enabled == "true" ? 1 : 0}"
-  template = "${file("${path.module}/userdata.tpl")}"
+  count    = var.enabled ? 1 : 0
+  template = file("${path.module}/userdata.tpl")
 
-  vars {
-    cluster_endpoint           = "${var.cluster_endpoint}"
-    certificate_authority_data = "${var.cluster_certificate_authority_data}"
-    cluster_name               = "${var.cluster_name}"
-    bootstrap_extra_args       = "${var.bootstrap_extra_args}"
+  vars = {
+    cluster_endpoint           = var.cluster_endpoint
+    certificate_authority_data = var.cluster_certificate_authority_data
+    cluster_name               = var.cluster_name
+    bootstrap_extra_args       = var.bootstrap_extra_args
   }
 }
 
 data "aws_iam_instance_profile" "default" {
-  count = "${var.enabled == "true" && var.use_existing_aws_iam_instance_profile == "true" ? 1 : 0}"
-  name  = "${var.aws_iam_instance_profile_name}"
+  count = var.enabled && var.aws_iam_instance_profile_name != null ? 1 : 0
+  name  = var.aws_iam_instance_profile_name
 }
 
 data "template_file" "config_map_aws_auth" {
-  count    = "${var.enabled == "true" ? 1 : 0}"
-  template = "${file("${path.module}/config_map_aws_auth.tpl")}"
+  count    = var.enabled ? 1 : 0
+  template = file("${path.module}/config_map_aws_auth.tpl")
 
-  vars {
-    aws_iam_role_arn = "${var.use_existing_aws_iam_instance_profile == "true" ?  join("", data.aws_iam_instance_profile.default.*.role_arn) : join("", aws_iam_role.default.*.arn)}"
+  vars = {
+    aws_iam_role_arn = var.aws_iam_instance_profile_name != null ? join("", data.aws_iam_instance_profile.default.*.role_arn) : join("", aws_iam_role.default.*.arn)
   }
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,84 +1,85 @@
 output "launch_template_id" {
   description = "The ID of the launch template"
-  value       = "${module.autoscale_group.launch_template_id}"
+  value       = module.autoscale_group.launch_template_id
 }
 
 output "launch_template_arn" {
   description = "ARN of the launch template"
-  value       = "${module.autoscale_group.launch_template_arn}"
+  value       = module.autoscale_group.launch_template_arn
 }
 
 output "autoscaling_group_id" {
   description = "The AutoScaling Group ID"
-  value       = "${module.autoscale_group.autoscaling_group_id}"
+  value       = module.autoscale_group.autoscaling_group_id
 }
 
 output "autoscaling_group_name" {
   description = "The AutoScaling Group name"
-  value       = "${module.autoscale_group.autoscaling_group_name}"
+  value       = module.autoscale_group.autoscaling_group_name
 }
 
 output "autoscaling_group_arn" {
   description = "ARN of the AutoScaling Group"
-  value       = "${module.autoscale_group.autoscaling_group_arn}"
+  value       = module.autoscale_group.autoscaling_group_arn
 }
 
 output "autoscaling_group_min_size" {
   description = "The minimum size of the AutoScaling Group"
-  value       = "${module.autoscale_group.autoscaling_group_min_size}"
+  value       = module.autoscale_group.autoscaling_group_min_size
 }
 
 output "autoscaling_group_max_size" {
   description = "The maximum size of the AutoScaling Group"
-  value       = "${module.autoscale_group.autoscaling_group_max_size}"
+  value       = module.autoscale_group.autoscaling_group_max_size
 }
 
 output "autoscaling_group_desired_capacity" {
   description = "The number of Amazon EC2 instances that should be running in the group"
-  value       = "${module.autoscale_group.autoscaling_group_desired_capacity}"
+  value       = module.autoscale_group.autoscaling_group_desired_capacity
 }
 
 output "autoscaling_group_default_cooldown" {
   description = "Time between a scaling activity and the succeeding scaling activity"
-  value       = "${module.autoscale_group.autoscaling_group_default_cooldown}"
+  value       = module.autoscale_group.autoscaling_group_default_cooldown
 }
 
 output "autoscaling_group_health_check_grace_period" {
   description = "Time after instance comes into service before checking health"
-  value       = "${module.autoscale_group.autoscaling_group_health_check_grace_period}"
+  value       = module.autoscale_group.autoscaling_group_health_check_grace_period
 }
 
 output "autoscaling_group_health_check_type" {
   description = "`EC2` or `ELB`. Controls how health checking is done"
-  value       = "${module.autoscale_group.autoscaling_group_health_check_type}"
+  value       = module.autoscale_group.autoscaling_group_health_check_type
 }
 
 output "security_group_id" {
   description = "ID of the worker nodes Security Group"
-  value       = "${join("", aws_security_group.default.*.id)}"
+  value       = join("", aws_security_group.default.*.id)
 }
 
 output "security_group_arn" {
   description = "ARN of the worker nodes Security Group"
-  value       = "${join("", aws_security_group.default.*.arn)}"
+  value       = join("", aws_security_group.default.*.arn)
 }
 
 output "security_group_name" {
   description = "Name of the worker nodes Security Group"
-  value       = "${join("", aws_security_group.default.*.name)}"
+  value       = join("", aws_security_group.default.*.name)
 }
 
 output "worker_role_arn" {
   description = "ARN of the worker nodes IAM role"
-  value       = "${join("", aws_iam_role.default.*.arn)}"
+  value       = join("", aws_iam_role.default.*.arn)
 }
 
 output "worker_role_name" {
   description = "Name of the worker nodes IAM role"
-  value       = "${join("", aws_iam_role.default.*.name)}"
+  value       = join("", aws_iam_role.default.*.name)
 }
 
 output "config_map_aws_auth" {
   description = "Kubernetes ConfigMap configuration for worker nodes to join the EKS cluster. https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#required-kubernetes-configuration-to-join-worker-nodes"
-  value       = "${join("", data.template_file.config_map_aws_auth.*.rendered)}"
+  value       = join("", data.template_file.config_map_aws_auth.*.rendered)
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,173 +1,204 @@
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace, which could be your organization name, e.g. 'eg' or 'cp'"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage, e.g. 'prod', 'staging', 'dev', or 'test'"
 }
 
 variable "environment" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Environment, e.g. 'testing', 'UAT'"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   default     = "app"
   description = "Solution name, e.g. 'app' or 'cluster'"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional attributes (e.g. `1`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. `{ BusinessUnit = \"XYZ\" }`"
 }
 
 variable "enabled" {
-  type        = "string"
+  type        = bool
   description = "Whether to create the resources. Set to `false` to prevent the module from creating any resources"
-  default     = "true"
+  default     = true
 }
 
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "The name of the EKS cluster"
 }
 
 variable "cluster_endpoint" {
-  type        = "string"
+  type        = string
   description = "EKS cluster endpoint"
 }
 
 variable "cluster_certificate_authority_data" {
-  type        = "string"
+  type        = string
   description = "The base64 encoded certificate data required to communicate with the cluster"
 }
 
 variable "cluster_security_group_id" {
-  type        = "string"
+  type        = string
   description = "Security Group ID of the EKS cluster"
 }
 
 variable "vpc_id" {
-  type        = "string"
+  type        = string
   description = "VPC ID for the EKS cluster"
 }
 
 variable "allowed_security_groups" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of Security Group IDs to be allowed to connect to the worker nodes"
 }
 
 variable "allowed_cidr_blocks" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of CIDR blocks to be allowed to connect to the worker nodes"
 }
 
 variable "instance_initiated_shutdown_behavior" {
-  type        = "string"
+  type        = string
   description = "Shutdown behavior for the instances. Can be `stop` or `terminate`"
   default     = "terminate"
 }
 
 variable "image_id" {
-  type        = "string"
+  type        = string
   description = "EC2 image ID to launch. If not provided, the module will lookup the most recent EKS AMI. See https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html for more details on EKS-optimized images"
-  default     = ""
-}
-
-variable "use_custom_image_id" {
-  type        = "string"
-  description = "If set to `true`, will use variable `image_id` to run EKS workers inside autoscaling group"
-  default     = "false"
+  default     = null
 }
 
 variable "eks_worker_ami_name_filter" {
-  type        = "string"
+  type        = string
   description = "AMI name filter to lookup the most recent EKS AMI if `image_id` is not provided"
   default     = "amazon-eks-node-*"
 }
 
 variable "eks_worker_ami_name_regex" {
-  type        = "string"
+  type        = string
   description = "A regex string to apply to the AMI list returned by AWS"
   default     = "^amazon-eks-node-[1-9,\\.]+-v\\d{8}$"
 }
 
 variable "instance_type" {
-  type        = "string"
+  type        = string
   description = "Instance type to launch"
 }
 
 variable "key_name" {
-  type        = "string"
+  type        = string
   description = "SSH key name that should be used for the instance"
   default     = ""
 }
 
 variable "associate_public_ip_address" {
+  type        = bool
   description = "Associate a public IP address with an instance in a VPC"
   default     = false
 }
 
 variable "enable_monitoring" {
+  type        = bool
   description = "Enable/disable detailed monitoring"
   default     = true
 }
 
 variable "ebs_optimized" {
+  type        = bool
   description = "If true, the launched EC2 instance will be EBS-optimized"
   default     = false
 }
 
 variable "block_device_mappings" {
   description = "Specify volumes to attach to the instance besides the volumes specified by the AMI"
-  type        = "list"
-  default     = []
+  type = list(object({
+    device_name  = string,
+    no_device    = string,
+    virtual_name = string,
+    ebs = object({
+      delete_on_termination = bool,
+      encrypted             = bool,
+      iops                  = number,
+      kms_key_id            = string,
+      snapshot_id           = string,
+      volume_size           = string,
+      volume_type           = string
+    })
+  }))
+  default = []
 }
 
 variable "instance_market_options" {
   description = "The market (purchasing) option for the instances"
-  type        = "list"
-  default     = []
+  type = list(object({
+    market_type = string,
+    spot_options = object({
+      block_duration_minutes         = number,
+      instance_interruption_behavior = string,
+      max_price                      = string,
+      spot_instance_type             = string,
+      valid_until                    = string,
+    })
+  }))
+  default = []
 }
 
 variable "placement" {
   description = "The placement specifications of the instances"
-  type        = "list"
-  default     = []
+  type = list(object({
+    affinity          = string,
+    availability_zone = string,
+    group_name        = string,
+    host_id           = string,
+    spread_domain     = string,
+    tenancy           = string
+  }))
+  default = []
 }
 
 variable "credit_specification" {
   description = "Customize the credit specification of the instances"
-  type        = "list"
-  default     = []
+  type = list(object({
+    cpu_credits = string
+  }))
+  default = []
 }
 
 variable "elastic_gpu_specifications" {
   description = "Specifications of Elastic GPU to attach to the instances"
-  type        = "list"
-  default     = []
+  type = list(object({
+    type = string
+  }))
+  default = []
 }
 
 variable "disable_api_termination" {
+  type        = bool
   description = "If `true`, enables EC2 Instance Termination Protection"
   default     = false
 }
@@ -182,7 +213,7 @@ variable "min_size" {
 
 variable "subnet_ids" {
   description = "A list of subnet IDs to launch resources in"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "default_cooldown" {
@@ -196,55 +227,56 @@ variable "health_check_grace_period" {
 }
 
 variable "health_check_type" {
-  type        = "string"
+  type        = string
   description = "Controls how health checking is done. Valid values are `EC2` or `ELB`"
   default     = "EC2"
 }
 
 variable "force_delete" {
+  type        = bool
   description = "Allows deleting the autoscaling group without waiting for all instances in the pool to terminate. You can force an autoscaling group to delete even if it's in the process of scaling a resource. Normally, Terraform drains all the instances before deleting the group. This bypasses that behavior and potentially leaves resources dangling"
   default     = false
 }
 
 variable "load_balancers" {
-  type        = "list"
+  type        = list(string)
   description = "A list of elastic load balancer names to add to the autoscaling group names. Only valid for classic load balancers. For ALBs, use `target_group_arns` instead"
   default     = []
 }
 
 variable "target_group_arns" {
-  type        = "list"
+  type        = list(string)
   description = "A list of aws_alb_target_group ARNs, for use with Application Load Balancing"
   default     = []
 }
 
 variable "termination_policies" {
   description = "A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default`"
-  type        = "list"
+  type        = list(string)
   default     = ["Default"]
 }
 
 variable "suspended_processes" {
-  type        = "list"
+  type        = list(string)
   description = "A list of processes to suspend for the AutoScaling Group. The allowed values are `Launch`, `Terminate`, `HealthCheck`, `ReplaceUnhealthy`, `AZRebalance`, `AlarmNotification`, `ScheduledActions`, `AddToLoadBalancer`. Note that if you suspend either the `Launch` or `Terminate` process types, it can prevent your autoscaling group from functioning properly."
   default     = []
 }
 
 variable "placement_group" {
-  type        = "string"
+  type        = string
   description = "The name of the placement group into which you'll launch your instances, if any"
   default     = ""
 }
 
 variable "metrics_granularity" {
-  type        = "string"
+  type        = string
   description = "The granularity to associate with the metrics to collect. The only valid value is 1Minute"
   default     = "1Minute"
 }
 
 variable "enabled_metrics" {
   description = "A list of metrics to collect. The allowed values are `GroupMinSize`, `GroupMaxSize`, `GroupDesiredCapacity`, `GroupInServiceInstances`, `GroupPendingInstances`, `GroupStandbyInstances`, `GroupTerminatingInstances`, `GroupTotalInstances`"
-  type        = "list"
+  type        = list(string)
 
   default = [
     "GroupMinSize",
@@ -259,7 +291,7 @@ variable "enabled_metrics" {
 }
 
 variable "wait_for_capacity_timeout" {
-  type        = "string"
+  type        = string
   description = "A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior"
   default     = "10m"
 }
@@ -270,29 +302,31 @@ variable "min_elb_capacity" {
 }
 
 variable "wait_for_elb_capacity" {
+  type        = number
   description = "Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior"
-  default     = false
+  default     = null
 }
 
 variable "protect_from_scale_in" {
+  type        = bool
   description = "Allows setting instance protection. The autoscaling group will not select instances with this setting for terminination during scale in events"
   default     = false
 }
 
 variable "service_linked_role_arn" {
-  type        = "string"
+  type        = string
   description = "The ARN of the service-linked role that the ASG will use to call other AWS services"
   default     = ""
 }
 
 variable "autoscaling_policies_enabled" {
-  type        = "string"
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Whether to create `aws_autoscaling_policy` and `aws_cloudwatch_metric_alarm` resources to control Auto Scaling"
 }
 
 variable "scale_up_cooldown_seconds" {
-  type        = "string"
+  type        = string
   default     = "300"
   description = "The amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start"
 }
@@ -303,19 +337,19 @@ variable "scale_up_scaling_adjustment" {
 }
 
 variable "scale_up_adjustment_type" {
-  type        = "string"
+  type        = string
   default     = "ChangeInCapacity"
   description = "Specifies whether the adjustment is an absolute number or a percentage of the current capacity. Valid values are `ChangeInCapacity`, `ExactCapacity` and `PercentChangeInCapacity`"
 }
 
 variable "scale_up_policy_type" {
-  type        = "string"
+  type        = string
   default     = "SimpleScaling"
   description = "The scalling policy type, either `SimpleScaling`, `StepScaling` or `TargetTrackingScaling`"
 }
 
 variable "scale_down_cooldown_seconds" {
-  type        = "string"
+  type        = string
   default     = "300"
   description = "The amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start"
 }
@@ -326,109 +360,98 @@ variable "scale_down_scaling_adjustment" {
 }
 
 variable "scale_down_adjustment_type" {
-  type        = "string"
+  type        = string
   default     = "ChangeInCapacity"
   description = "Specifies whether the adjustment is an absolute number or a percentage of the current capacity. Valid values are `ChangeInCapacity`, `ExactCapacity` and `PercentChangeInCapacity`"
 }
 
 variable "scale_down_policy_type" {
-  type        = "string"
+  type        = string
   default     = "SimpleScaling"
   description = "The scalling policy type, either `SimpleScaling`, `StepScaling` or `TargetTrackingScaling`"
 }
 
 variable "cpu_utilization_high_evaluation_periods" {
-  type        = "string"
+  type        = string
   default     = "2"
   description = "The number of periods over which data is compared to the specified threshold"
 }
 
 variable "cpu_utilization_high_period_seconds" {
-  type        = "string"
+  type        = string
   default     = "300"
   description = "The period in seconds over which the specified statistic is applied"
 }
 
 variable "cpu_utilization_high_threshold_percent" {
-  type        = "string"
+  type        = string
   default     = "90"
   description = "The value against which the specified statistic is compared"
 }
 
 variable "cpu_utilization_high_statistic" {
-  type        = "string"
+  type        = string
   default     = "Average"
   description = "The statistic to apply to the alarm's associated metric. Either of the following is supported: `SampleCount`, `Average`, `Sum`, `Minimum`, `Maximum`"
 }
 
 variable "cpu_utilization_low_evaluation_periods" {
-  type        = "string"
+  type        = string
   default     = "2"
   description = "The number of periods over which data is compared to the specified threshold"
 }
 
 variable "cpu_utilization_low_period_seconds" {
-  type        = "string"
+  type        = string
   default     = "300"
   description = "The period in seconds over which the specified statistic is applied"
 }
 
 variable "cpu_utilization_low_threshold_percent" {
-  type        = "string"
+  type        = string
   default     = "10"
   description = "The value against which the specified statistic is compared"
 }
 
 variable "cpu_utilization_low_statistic" {
-  type        = "string"
+  type        = string
   default     = "Average"
   description = "The statistic to apply to the alarm's associated metric. Either of the following is supported: `SampleCount`, `Average`, `Sum`, `Minimum`, `Maximum`"
 }
 
 variable "bootstrap_extra_args" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Passed to the bootstrap.sh script to enable --kublet-extra-args or --use-max-pods."
 }
 
 variable "aws_iam_instance_profile_name" {
-  type        = "string"
-  default     = ""
+  type        = string
+  default     = null
   description = "The name of the existing instance profile that will be used in autoscaling group for EKS workers. If empty will create a new instance profile."
 }
 
 variable "workers_security_group_id" {
-  type        = "string"
-  default     = ""
+  type        = string
+  default     = null
   description = "The name of the existing security group that will be used in autoscaling group for EKS workers. If empty, a new security group will be created"
 }
 
-variable "use_existing_security_group" {
-  type        = "string"
-  description = "If set to `true`, will use variable `workers_security_group_id` to run EKS workers using an existing security group that was created outside of this module, workaround for errors like `count cannot be computed`"
-  default     = "false"
-}
-
 variable "additional_security_group_ids" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional list of security groups that will be attached to the autoscaling group"
 }
 
-variable "use_existing_aws_iam_instance_profile" {
-  type        = "string"
-  description = "If set to `true`, will use variable `aws_iam_instance_profile_name` to run EKS workers using an existing AWS instance profile that was created outside of this module, workaround for error like `count cannot be computed`"
-  default     = "false"
-}
-
 variable "workers_role_policy_arns" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of policy ARNs that will be attached to the workers default role on creation"
 }
 
 variable "workers_role_policy_arns_count" {
-  type        = "string"
+  type        = string
   default     = "0"
   description = "Count of policy ARNs that will be attached to the workers default role on creation. Needed to prevent Terraform error `count can't be computed`"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Note, this depends on https://github.com/cloudposse/terraform-aws-ec2-autoscale-group/pull/14 getting merged and then making a change here to reference that new tag.

This does the upgrade and also copies the new arguments relevant to the underlying autoscale group. It also removes some arguments we no longer need because of the addition of "null" that allows us to remove the accompanying boolean values.

The example is not ported as some of the dependency modules aren't 0.12 compatible.

