### PR TITLE
Add `var.cluster_security_group_ingress_enabled`

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Available targets:
 | cluster_endpoint | EKS cluster endpoint | string | - | yes |
 | cluster_name | The name of the EKS cluster | string | - | yes |
 | cluster_security_group_id | Security Group ID of the EKS cluster | string | - | yes |
+| cluster_security_group_ingress_enabled | Whether to enable the EKS cluster Security Group as ingress to workers Security Group | bool | `true` | no |
 | cpu_utilization_high_evaluation_periods | The number of periods over which data is compared to the specified threshold | number | `2` | no |
 | cpu_utilization_high_period_seconds | The period in seconds over which the specified statistic is applied | number | `300` | no |
 | cpu_utilization_high_statistic | The statistic to apply to the alarm's associated metric. Either of the following is supported: `SampleCount`, `Average`, `Sum`, `Minimum`, `Maximum` | string | `Average` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -15,6 +15,7 @@
 | cluster_endpoint | EKS cluster endpoint | string | - | yes |
 | cluster_name | The name of the EKS cluster | string | - | yes |
 | cluster_security_group_id | Security Group ID of the EKS cluster | string | - | yes |
+| cluster_security_group_ingress_enabled | Whether to enable the EKS cluster Security Group as ingress to workers Security Group | bool | `true` | no |
 | cpu_utilization_high_evaluation_periods | The number of periods over which data is compared to the specified threshold | number | `2` | no |
 | cpu_utilization_high_period_seconds | The period in seconds over which the specified statistic is applied | number | `300` | no |
 | cpu_utilization_high_statistic | The statistic to apply to the alarm's associated metric. Either of the following is supported: `SampleCount`, `Average`, `Sum`, `Minimum`, `Maximum` | string | `Average` | no |

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -29,3 +29,5 @@ cluster_name = "eg-test-eks-workers-cluster"
 cluster_endpoint = ""
 
 cluster_certificate_authority_data = ""
+
+cluster_security_group_ingress_enabled = false

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -33,21 +33,22 @@ module "subnets" {
 }
 
 module "eks_workers" {
-  source                             = "../../"
-  namespace                          = var.namespace
-  stage                              = var.stage
-  name                               = var.name
-  instance_type                      = var.instance_type
-  vpc_id                             = module.vpc.vpc_id
-  subnet_ids                         = module.subnets.public_subnet_ids
-  health_check_type                  = var.health_check_type
-  min_size                           = var.min_size
-  max_size                           = var.max_size
-  wait_for_capacity_timeout          = var.wait_for_capacity_timeout
-  cluster_name                       = var.cluster_name
-  cluster_endpoint                   = var.cluster_endpoint
-  cluster_certificate_authority_data = var.cluster_certificate_authority_data
-  cluster_security_group_id          = var.cluster_security_group_id
+  source                                 = "../../"
+  namespace                              = var.namespace
+  stage                                  = var.stage
+  name                                   = var.name
+  instance_type                          = var.instance_type
+  vpc_id                                 = module.vpc.vpc_id
+  subnet_ids                             = module.subnets.public_subnet_ids
+  health_check_type                      = var.health_check_type
+  min_size                               = var.min_size
+  max_size                               = var.max_size
+  wait_for_capacity_timeout              = var.wait_for_capacity_timeout
+  cluster_name                           = var.cluster_name
+  cluster_endpoint                       = var.cluster_endpoint
+  cluster_certificate_authority_data     = var.cluster_certificate_authority_data
+  cluster_security_group_id              = var.cluster_security_group_id
+  cluster_security_group_ingress_enabled = var.cluster_security_group_ingress_enabled
 
   # Auto-scaling policies and CloudWatch metric alarms
   autoscaling_policies_enabled           = var.autoscaling_policies_enabled

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -44,6 +44,11 @@ variable "cluster_certificate_authority_data" {
   description = "The base64 encoded certificate data required to communicate with the cluster"
 }
 
+variable "cluster_security_group_ingress_enabled" {
+  type        = bool
+  description = "Whether to enable the EKS cluster Security Group as ingress to workers Security Group"
+}
+
 variable "cluster_security_group_id" {
   type        = string
   description = "Security Group ID of the EKS cluster"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,5 +4,6 @@ terraform {
   required_providers {
     aws      = "~> 2.0"
     template = "~> 2.0"
+    local    = "~> 1.3"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,7 @@ resource "aws_security_group_rule" "ingress_self" {
 }
 
 resource "aws_security_group_rule" "ingress_cluster" {
-  count                    = var.enabled && var.cluster_security_group_id != "" && var.use_existing_security_group == false ? 1 : 0
+  count                    = var.enabled && var.cluster_security_group_ingress_enabled && var.use_existing_security_group == false ? 1 : 0
   description              = "Allow worker kubelets and pods to receive communication from the cluster control plane"
   from_port                = 0
   to_port                  = 65535

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,12 @@ variable "cluster_certificate_authority_data" {
   description = "The base64 encoded certificate data required to communicate with the cluster"
 }
 
+variable "cluster_security_group_ingress_enabled" {
+  type        = bool
+  description = "Whether to enable the EKS cluster Security Group as ingress to workers Security Group"
+  default     = true
+}
+
 variable "cluster_security_group_id" {
   type        = string
   description = "Security Group ID of the EKS cluster"

--- a/versions.tf
+++ b/versions.tf
@@ -4,5 +4,6 @@ terraform {
   required_providers {
     aws      = "~> 2.0"
     template = "~> 2.0"
+    local    = "~> 1.3"
   }
 }


### PR DESCRIPTION
## what
* Add `var.cluster_security_group_ingress_enabled` 

## why
* To fix `count can't be computed` error
* To be able to use this module in standalone tests and with `terraform-aws-eks-cluster` module:

  - When this module is connected to `terraform-aws-eks-cluster` module, the condition `var.enabled && var.cluster_security_group_id != ""`  in `count` throws `count can't be computed` error
  - When this module is used in tests, `terraform-aws-eks-cluster` module is not present and we don't have `var.cluster_security_group_id` defined, so we need to disable `resource "aws_security_group_rule" "ingress_cluster"` when testing