### PR TITLE
fix(bootstrap-extra-args): Use KUBELET_EXTRA_ARGS env variable to pass extra kubelet args

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -49,6 +49,7 @@ module "eks_workers" {
   cluster_certificate_authority_data     = var.cluster_certificate_authority_data
   cluster_security_group_id              = var.cluster_security_group_id
   cluster_security_group_ingress_enabled = var.cluster_security_group_ingress_enabled
+  bootstrap_extra_args                   = "--node-labels=purpose=ci-worker"
 
   # Auto-scaling policies and CloudWatch metric alarms
   autoscaling_policies_enabled           = var.autoscaling_policies_enabled

--- a/userdata.tpl
+++ b/userdata.tpl
@@ -2,9 +2,13 @@
 
 # userdata for EKS worker nodes to properly configure Kubernetes applications on EC2 instances
 # https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html
+# https://aws.amazon.com/blogs/opensource/improvements-eks-worker-node-provisioning/
+# https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh#L97
 
 ${before_cluster_joining_userdata}
 
-/etc/eks/bootstrap.sh --apiserver-endpoint '${cluster_endpoint}' --b64-cluster-ca '${certificate_authority_data}' ${bootstrap_extra_args} '${cluster_name}'
+export KUBELET_EXTRA_ARGS=${bootstrap_extra_args}
+
+/etc/eks/bootstrap.sh --apiserver-endpoint '${cluster_endpoint}' --b64-cluster-ca '${certificate_authority_data}' '${cluster_name}'
 
 ${after_cluster_joining_userdata}


### PR DESCRIPTION
I've faced with issue passing node labels to bootstrap.sh, the bootstrap cannot completed when we pass extra kubelet args as an argument, and thus node won't join to the kubernetes cluster.

Pass extra kubelet args via KUBELET_EXTRA_ARGS  solves this. 