### PR TITLE
Add mixed instance policy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,6 @@ Available targets:
 | key_name | SSH key name that should be used for the instance | string | `` | no |
 | load_balancers | A list of elastic load balancer names to add to the autoscaling group. Only valid for classic load balancers. For ALBs, use `target_group_arns` instead | list(string) | `<list>` | no |
 | max_size | The maximum size of the autoscale group | number | - | yes |
-| mixed_instances_policy | Policy to use mixed group of on demand/spot of differing types | object | `null` | no |
 | metrics_granularity | The granularity to associate with the metrics to collect. The only valid value is 1Minute | string | `1Minute` | no |
 | min_elb_capacity | Setting this causes Terraform to wait for this number of instances to show up healthy in the ELB only on creation. Updates will not wait on ELB instance number changes | number | `0` | no |
 | min_size | The minimum size of the autoscale group | number | - | yes |

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Available targets:
 | key_name | SSH key name that should be used for the instance | string | `` | no |
 | load_balancers | A list of elastic load balancer names to add to the autoscaling group. Only valid for classic load balancers. For ALBs, use `target_group_arns` instead | list(string) | `<list>` | no |
 | max_size | The maximum size of the autoscale group | number | - | yes |
+| mixed_instances_policy | Policy to use mixed group of on demand/spot of differing types | object | `null` | no |
 | metrics_granularity | The granularity to associate with the metrics to collect. The only valid value is 1Minute | string | `1Minute` | no |
 | min_elb_capacity | Setting this causes Terraform to wait for this number of instances to show up healthy in the ELB only on creation. Updates will not wait on ELB instance number changes | number | `0` | no |
 | min_size | The minimum size of the autoscale group | number | - | yes |

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Available targets:
 | metrics_granularity | The granularity to associate with the metrics to collect. The only valid value is 1Minute | string | `1Minute` | no |
 | min_elb_capacity | Setting this causes Terraform to wait for this number of instances to show up healthy in the ELB only on creation. Updates will not wait on ELB instance number changes | number | `0` | no |
 | min_size | The minimum size of the autoscale group | number | - | yes |
+| mixed_instances_policy | policy to used mixed group of on demand/spot of differing types. Launch template is automatically generated. https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#mixed_instances_policy-1 | object | `null` | no |
 | name | Solution name, e.g. 'app' or 'cluster' | string | `app` | no |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | `` | no |
 | placement | The placement specifications of the instances | object | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -50,6 +50,7 @@
 | metrics_granularity | The granularity to associate with the metrics to collect. The only valid value is 1Minute | string | `1Minute` | no |
 | min_elb_capacity | Setting this causes Terraform to wait for this number of instances to show up healthy in the ELB only on creation. Updates will not wait on ELB instance number changes | number | `0` | no |
 | min_size | The minimum size of the autoscale group | number | - | yes |
+| mixed_instances_policy | policy to used mixed group of on demand/spot of differing types. Launch template is automatically generated. https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#mixed_instances_policy-1 | object | `null` | no |
 | name | Solution name, e.g. 'app' or 'cluster' | string | `app` | no |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | `` | no |
 | placement | The placement specifications of the instances | object | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -169,7 +169,7 @@ data "aws_iam_instance_profile" "default" {
 }
 
 module "autoscale_group" {
-  source = "git::https://github.com/cloudposse/terraform-aws-ec2-autoscale-group.git?ref=tags/0.3.0"
+  source = "git::https://github.com/cloudposse/terraform-aws-ec2-autoscale-group.git?ref=tags/0.4.0"
 
   enabled    = var.enabled
   namespace  = var.namespace

--- a/main.tf
+++ b/main.tf
@@ -169,7 +169,7 @@ data "aws_iam_instance_profile" "default" {
 }
 
 module "autoscale_group" {
-  source = "git::https://github.com/cloudposse/terraform-aws-ec2-autoscale-group.git?ref=tags/0.2.1"
+  source = "git::https://github.com/cloudposse/terraform-aws-ec2-autoscale-group.git?ref=tags/0.3.0"
 
   enabled    = var.enabled
   namespace  = var.namespace
@@ -205,6 +205,7 @@ module "autoscale_group" {
   elastic_gpu_specifications              = var.elastic_gpu_specifications
   instance_initiated_shutdown_behavior    = var.instance_initiated_shutdown_behavior
   instance_market_options                 = var.instance_market_options
+  mixed_instances_policy                  = var.mixed_instances_policy
   key_name                                = var.key_name
   placement                               = var.placement
   enable_monitoring                       = var.enable_monitoring

--- a/variables.tf
+++ b/variables.tf
@@ -469,7 +469,7 @@ variable "instance_market_options" {
   default = null
 }
 
-variable mixed_instances_policy {
+variable "mixed_instances_policy" {
   description = "policy to used mixed group of on demand/spot of differing types. Launch template is automatically generated. https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#mixed_instances_policy-1"
 
   type = object({

--- a/variables.tf
+++ b/variables.tf
@@ -469,6 +469,26 @@ variable "instance_market_options" {
   default = null
 }
 
+variable mixed_instances_policy {
+  description = "policy to used mixed group of on demand/spot of differing types. Launch template is automatically generated. https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#mixed_instances_policy-1"
+
+  type = object({
+    instances_distribution = object({
+      on_demand_allocation_strategy            = string
+      on_demand_base_capacity                  = number
+      on_demand_percentage_above_base_capacity = number
+      spot_allocation_strategy                 = string
+      spot_instance_pools                      = number
+      spot_max_price                           = string
+    })
+    override = list(object({
+      instance_type     = string
+      weighted_capacity = number
+    }))
+  })
+  default = null
+}
+
 variable "placement" {
   description = "The placement specifications of the instances"
 


### PR DESCRIPTION
https://github.com/cloudposse/terraform-aws-ec2-autoscale-group/pull/19 adds support for the ability to specify different instances  types and spot/on demand configurations for a launch template. This extends this functionality to eks nodes