### PR TITLE
Restore bootstrap extra args, add Autoscaler tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,12 @@ Available targets:
 | allowed_security_groups | List of Security Group IDs to be allowed to connect to the worker nodes | list(string) | `<list>` | no |
 | associate_public_ip_address | Associate a public IP address with an instance in a VPC | bool | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
+| autoscaling_group_tags | Additional tags only for the autoscaling group, e.g. "k8s.io/cluster-autoscaler/node-template/taint/dedicated" = "ci-cd:NoSchedule". | map(string) | `<map>` | no |
 | autoscaling_policies_enabled | Whether to create `aws_autoscaling_policy` and `aws_cloudwatch_metric_alarm` resources to control Auto Scaling | bool | `true` | no |
 | aws_iam_instance_profile_name | The name of the existing instance profile that will be used in autoscaling group for EKS workers. If empty will create a new instance profile. | string | `` | no |
 | before_cluster_joining_userdata | Additional commands to execute on each worker node before joining the EKS cluster (before executing the `bootstrap.sh` script). For mot info, see https://kubedex.com/90-days-of-aws-eks-in-production | string | `` | no |
 | block_device_mappings | Specify volumes to attach to the instance besides the volumes specified by the AMI | object | `<list>` | no |
-| bootstrap_extra_args | Passed to the `bootstrap.sh` script to enable `--kublet-extra-args` or `--use-max-pods` | string | `` | no |
+| bootstrap_extra_args | Extra arguments to the `bootstrap.sh` script to enable `--enable-docker-bridge` or `--use-max-pods` | string | `` | no |
 | cluster_certificate_authority_data | The base64 encoded certificate data required to communicate with the cluster | string | - | yes |
 | cluster_endpoint | EKS cluster endpoint | string | - | yes |
 | cluster_name | The name of the EKS cluster | string | - | yes |
@@ -221,6 +222,7 @@ Available targets:
 | instance_market_options | The market (purchasing) option for the instances | object | `null` | no |
 | instance_type | Instance type to launch | string | - | yes |
 | key_name | SSH key name that should be used for the instance | string | `` | no |
+| kubelet_extra_args | Extra arguments to pass to kubelet, like "--register-with-taints=dedicated=ci-cd:NoSchedule --node-labels=purpose=ci-worker" | string | `` | no |
 | load_balancers | A list of elastic load balancer names to add to the autoscaling group. Only valid for classic load balancers. For ALBs, use `target_group_arns` instead | list(string) | `<list>` | no |
 | max_size | The maximum size of the autoscale group | number | - | yes |
 | metrics_granularity | The granularity to associate with the metrics to collect. The only valid value is 1Minute | string | `1Minute` | no |
@@ -338,6 +340,10 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 
 Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
 
+## Discourse Forums
+
+Participate in our [Discourse Forums][discourse]. Here you'll find answers to commonly asked questions. Most questions will be related to the enormous number of projects we support on our GitHub. Come here to collaborate on answers, find solutions, and get ideas about the products and services we value. It only takes a minute to get started! Just sign in with SSO using your GitHub account.
+
 ## Newsletter
 
 Sign up for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover. 
@@ -451,6 +457,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [testimonial]: https://cpco.io/leave-testimonial?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-eks-workers&utm_content=testimonial
   [office_hours]: https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-eks-workers&utm_content=office_hours
   [newsletter]: https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-eks-workers&utm_content=newsletter
+  [discourse]: https://ask.sweetops.com/?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-eks-workers&utm_content=discourse
   [email]: https://cpco.io/email?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-eks-workers&utm_content=email
   [commercial_support]: https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-eks-workers&utm_content=commercial_support
   [we_love_open_source]: https://cpco.io/we-love-open-source?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-eks-workers&utm_content=we_love_open_source

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -8,11 +8,12 @@
 | allowed_security_groups | List of Security Group IDs to be allowed to connect to the worker nodes | list(string) | `<list>` | no |
 | associate_public_ip_address | Associate a public IP address with an instance in a VPC | bool | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
+| autoscaling_group_tags | Additional tags only for the autoscaling group, e.g. "k8s.io/cluster-autoscaler/node-template/taint/dedicated" = "ci-cd:NoSchedule". | map(string) | `<map>` | no |
 | autoscaling_policies_enabled | Whether to create `aws_autoscaling_policy` and `aws_cloudwatch_metric_alarm` resources to control Auto Scaling | bool | `true` | no |
 | aws_iam_instance_profile_name | The name of the existing instance profile that will be used in autoscaling group for EKS workers. If empty will create a new instance profile. | string | `` | no |
 | before_cluster_joining_userdata | Additional commands to execute on each worker node before joining the EKS cluster (before executing the `bootstrap.sh` script). For mot info, see https://kubedex.com/90-days-of-aws-eks-in-production | string | `` | no |
 | block_device_mappings | Specify volumes to attach to the instance besides the volumes specified by the AMI | object | `<list>` | no |
-| bootstrap_extra_args | Passed to the `bootstrap.sh` script to enable `--kublet-extra-args` or `--use-max-pods` | string | `` | no |
+| bootstrap_extra_args | Extra arguments to the `bootstrap.sh` script to enable `--enable-docker-bridge` or `--use-max-pods` | string | `` | no |
 | cluster_certificate_authority_data | The base64 encoded certificate data required to communicate with the cluster | string | - | yes |
 | cluster_endpoint | EKS cluster endpoint | string | - | yes |
 | cluster_name | The name of the EKS cluster | string | - | yes |
@@ -45,6 +46,7 @@
 | instance_market_options | The market (purchasing) option for the instances | object | `null` | no |
 | instance_type | Instance type to launch | string | - | yes |
 | key_name | SSH key name that should be used for the instance | string | `` | no |
+| kubelet_extra_args | Extra arguments to pass to kubelet, like "--register-with-taints=dedicated=ci-cd:NoSchedule --node-labels=purpose=ci-worker" | string | `` | no |
 | load_balancers | A list of elastic load balancer names to add to the autoscaling group. Only valid for classic load balancers. For ALBs, use `target_group_arns` instead | list(string) | `<list>` | no |
 | max_size | The maximum size of the autoscale group | number | - | yes |
 | metrics_granularity | The granularity to associate with the metrics to collect. The only valid value is 1Minute | string | `1Minute` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -49,7 +49,8 @@ module "eks_workers" {
   cluster_certificate_authority_data     = var.cluster_certificate_authority_data
   cluster_security_group_id              = var.cluster_security_group_id
   cluster_security_group_ingress_enabled = var.cluster_security_group_ingress_enabled
-  bootstrap_extra_args                   = "--node-labels=purpose=ci-worker"
+  bootstrap_extra_args                   = "--use-max-pods false"
+  kubelet_extra_args                     = "--node-labels=purpose=ci-worker"
 
   # Auto-scaling policies and CloudWatch metric alarms
   autoscaling_policies_enabled           = var.autoscaling_policies_enabled

--- a/main.tf
+++ b/main.tf
@@ -158,6 +158,7 @@ data "template_file" "userdata" {
     certificate_authority_data      = var.cluster_certificate_authority_data
     cluster_name                    = var.cluster_name
     bootstrap_extra_args            = var.bootstrap_extra_args
+    kubelet_extra_args              = var.kubelet_extra_args
     before_cluster_joining_userdata = var.before_cluster_joining_userdata
     after_cluster_joining_userdata  = var.after_cluster_joining_userdata
   }
@@ -177,7 +178,7 @@ module "autoscale_group" {
   name       = var.name
   delimiter  = var.delimiter
   attributes = var.attributes
-  tags       = module.label.tags
+  tags       = merge(module.label.tags, var.autoscaling_group_tags)
 
   image_id                  = var.use_custom_image_id ? var.image_id : join("", data.aws_ami.eks_worker.*.id)
   iam_instance_profile_name = var.use_existing_aws_iam_instance_profile == false ? join("", aws_iam_instance_profile.default.*.name) : var.aws_iam_instance_profile_name

--- a/userdata.tpl
+++ b/userdata.tpl
@@ -7,8 +7,8 @@
 
 ${before_cluster_joining_userdata}
 
-export KUBELET_EXTRA_ARGS=${bootstrap_extra_args}
+export KUBELET_EXTRA_ARGS="${kubelet_extra_args}"
 
-/etc/eks/bootstrap.sh --apiserver-endpoint '${cluster_endpoint}' --b64-cluster-ca '${certificate_authority_data}' '${cluster_name}'
+/etc/eks/bootstrap.sh --apiserver-endpoint '${cluster_endpoint}' --b64-cluster-ca '${certificate_authority_data}' ${bootstrap_extra_args} '${cluster_name}'
 
 ${after_cluster_joining_userdata}

--- a/variables.tf
+++ b/variables.tf
@@ -269,6 +269,12 @@ variable "service_linked_role_arn" {
   default     = ""
 }
 
+variable "autoscaling_group_tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags only for the autoscaling group, e.g. \"k8s.io/cluster-autoscaler/node-template/taint/dedicated\" = \"ci-cd:NoSchedule\"."
+}
+
 variable "autoscaling_policies_enabled" {
   type        = bool
   default     = true
@@ -374,8 +380,15 @@ variable "cpu_utilization_low_statistic" {
 variable "bootstrap_extra_args" {
   type        = string
   default     = ""
-  description = "Passed to the `bootstrap.sh` script to enable `--kublet-extra-args` or `--use-max-pods`"
+  description = "Extra arguments to the `bootstrap.sh` script to enable `--enable-docker-bridge` or `--use-max-pods`"
 }
+
+variable "kubelet_extra_args" {
+  type        = string
+  default     = ""
+  description = "Extra arguments to pass to kubelet, like \"--register-with-taints=dedicated=ci-cd:NoSchedule --node-labels=purpose=ci-worker\""
+}
+
 
 variable "before_cluster_joining_userdata" {
   type        = string


### PR DESCRIPTION
## what

- Add `kubelet_extra_args` to allow passing extra arguments to `kubelet` 
- Restore behavior of `bootstrap_extra_args` to allow passing extra arguments to `bootstrap.sh`
- Add `autoscaling_group_tags` to allow passing tags only to the Auto Scaling Group that will not be applied elsewhere.

## why

#### `kubelet_extra_args` and `bootstrap_extra_args`

PR #6 introduced the `bootstrap_extra_args` parameter to allow passing extra arguments to the [`bootstrap.sh` script](https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh) that runs at the startup of Amazon Kubernetes AMIs. One of the arguments to `bootstrap.sh` is a list of extra arguments to pass to `kubelet`. Some people had trouble using this feature, so PR #27 made it easier to pass arguments to `kubelet` by passing the entire contents of `bootstrap_extra_args` to `kubelet`.

Unfortunately, #27 removed the ability to actually pass arguments to `bootstrap.sh`, and broke the expectation and documentation of the `bootstrap_extra_args` parameter. The PR restores `bootstrap_extra_args` to the behavior prior to #27 and adds `kubelet_extra_args` as a convenience to address the difficulty #27 was intended to address. 

#### `autoscaling_group_tags`

Certain tags are used to affect the behavior or the Cluster Autoscaler. It is distracting to have these tags applied to other resources, so a separate parameter allows targeting the tags to just the Autoscaler.

## references

- [Announcing `bootstrap.sh`](https://aws.amazon.com/blogs/opensource/improvements-eks-worker-node-provisioning/)
- [`bootstrap.sh` script](https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh)
- [`kubelet` argument reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)
- Some information about Cluster Autoscaler tags affecting behavior can be found [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md)