### PR TITLE
Use the latest label module to support the terraform 0.13

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ locals {
 }
 
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.15.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name


### PR DESCRIPTION
## what
Update label module to the latest version which already supports the terraform 0.13.

## why
 Error fix:
`Module module.eks-cluster.module.eks-cluster.module.label (from
git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0)
does not support Terraform version 0.13.0. To proceed, either choose another
supported Terraform version or update this version constraint. Version
constraints are normally set for good reason, so updating the constraint may
lead to other errors or unexpected behavior.`

## note
TBD: we should bump terraform-aws-ec2-autoscale-group moudle version when [PR](https://github.com/cloudposse/terraform-aws-ec2-autoscale-group/pull/31) is merged