### PR TITLE
Update ASG module to the latest version which already supports the terraform 0.13.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -170,7 +170,7 @@ data "aws_iam_instance_profile" "default" {
 }
 
 module "autoscale_group" {
-  source = "git::https://github.com/cloudposse/terraform-aws-ec2-autoscale-group.git?ref=tags/0.4.0"
+  source = "git::https://github.com/cloudposse/terraform-aws-ec2-autoscale-group.git?ref=tags/0.7.1"
 
   enabled    = var.enabled
   namespace  = var.namespace


### PR DESCRIPTION
## what
Update ASG module to the latest version which already supports the terraform 0.13.

## why
To make terraform-aws-eks-workers module compatible with 0.13 terraform version, all its submodules must also support 0.13.
The last submodule that needs to be updated is  terraform-aws-ec2-autoscale-group.