### PR TITLE
Add support for dynamically selecting image architecture. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Available targets:
 | disable\_api\_termination | If `true`, enables EC2 Instance Termination Protection | `bool` | `false` | no |
 | ebs\_optimized | If true, the launched EC2 instance will be EBS-optimized | `bool` | `false` | no |
 | eks\_worker\_ami\_name\_filter | AMI name filter to lookup the most recent EKS AMI if `image_id` is not provided | `string` | `"amazon-eks-node-*"` | no |
+| eks\_worker\_ami\arch\_filter | AMI architecture filter to select required image architecture if `image_id` is not provided. | `string` | `"x86_64"` | no |
 | eks\_worker\_ami\_name\_regex | A regex string to apply to the AMI list returned by AWS | `string` | `"^amazon-eks-node-[1-9,.]+-v[0-9]{8}$"` | no |
 | elastic\_gpu\_specifications | Specifications of Elastic GPU to attach to the instances | <pre>object({<br>    type = string<br>  })</pre> | `null` | no |
 | enable\_monitoring | Enable/disable detailed monitoring | `bool` | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -51,6 +51,7 @@
 | disable\_api\_termination | If `true`, enables EC2 Instance Termination Protection | `bool` | `false` | no |
 | ebs\_optimized | If true, the launched EC2 instance will be EBS-optimized | `bool` | `false` | no |
 | eks\_worker\_ami\_name\_filter | AMI name filter to lookup the most recent EKS AMI if `image_id` is not provided | `string` | `"amazon-eks-node-*"` | no |
+| eks\_worker\_ami\arch\_filter | AMI architecture filter to select required image architecture if `image_id` is not provided. | `string` | `"x86_64"` | no |
 | eks\_worker\_ami\_name\_regex | A regex string to apply to the AMI list returned by AWS | `string` | `"^amazon-eks-node-[1-9,.]+-v[0-9]{8}$"` | no |
 | elastic\_gpu\_specifications | Specifications of Elastic GPU to attach to the instances | <pre>object({<br>    type = string<br>  })</pre> | `null` | no |
 | enable\_monitoring | Enable/disable detailed monitoring | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -143,6 +143,11 @@ data "aws_ami" "eks_worker" {
     values = [var.eks_worker_ami_name_filter]
   }
 
+  filter {
+    name   = "architecture"
+    values = [var.eks_worker_ami_arch_filter]
+  }
+
   owners = ["602401143452"] # Amazon
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,12 @@ variable "eks_worker_ami_name_filter" {
   default     = "amazon-eks-node-*"
 }
 
+variable "eks_worker_ami_arch_filter" {
+  type        = string
+  description = "AMI architecture filter to select required image architecture if `image_id` is not provided. Possible options: x86_64, arm46, i386"
+  default     = "x86_64"
+}
+
 variable "eks_worker_ami_name_regex" {
   type        = string
   description = "A regex string to apply to the AMI list returned by AWS"


### PR DESCRIPTION
## what
* This PR will add support for selecting ami architecture.  I have added `eks_worker_ami_arch_filter` variable with default x86_64 and possibe options i386, x86_64 and arm64. This is required for eks graviton workers.
