### PR TITLE
Fix ASG tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -171,7 +171,7 @@ module "autoscale_group" {
   version = "0.22.0"
 
   enabled = local.enabled
-  tags    = var.autoscaling_group_tags
+  tags    = merge(module.label.tags, var.autoscaling_group_tags)
 
   image_id                  = var.use_custom_image_id ? var.image_id : join("", data.aws_ami.eks_worker.*.id)
   iam_instance_profile_name = var.use_existing_aws_iam_instance_profile == false ? join("", aws_iam_instance_profile.default.*.name) : var.aws_iam_instance_profile_name


### PR DESCRIPTION
## what

Fixes #62 

The ASG was not properly tagged and the workers were not able to join the cluster due to a missing tag with `"kubernetes.io/cluster/${var.cluster_name}" = "owned"`

Merges  `var.autoscaling_group_tags` with `module.label.tags`

## references
closes #62 

