### PR TITLE
feat: use security-group module instead of resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,27 @@ For a complete example, see [examples/complete](examples/complete)
     cluster_name                       = var.cluster_name
     cluster_endpoint                   = var.cluster_endpoint
     cluster_certificate_authority_data = var.cluster_certificate_authority_data
-    cluster_security_group_id          = var.cluster_security_group_id
+
+    security_group_rules = [
+      {
+        type                     = "egress"
+        from_port                = 0
+        to_port                  = 65535
+        protocol                 = "-1"
+        cidr_blocks              = ["0.0.0.0/0"]
+        source_security_group_id = null
+        description              = "Allow all outbound traffic"
+      },
+      {
+        type                     = "ingress"
+        from_port                = 0
+        to_port                  = 65535
+        protocol                 = "-1"
+        cidr_blocks              = []
+        source_security_group_id = "sg-XXXXXXXXX"
+        description              = "Allow all inbound traffic from Security Group ID of the EKS cluster"
+      }
+    ]
 
     # Auto-scaling policies and CloudWatch metric alarms
     autoscaling_policies_enabled           = var.autoscaling_policies_enabled
@@ -208,6 +228,7 @@ Available targets:
 |------|--------|---------|
 | <a name="module_autoscale_group"></a> [autoscale\_group](#module\_autoscale\_group) | cloudposse/ec2-autoscale-group/aws | 0.25.0 |
 | <a name="module_label"></a> [label](#module\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | cloudposse/security-group/aws | 0.3.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 
 ## Resources
@@ -220,12 +241,6 @@ Available targets:
 | [aws_iam_role_policy_attachment.amazon_eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.amazon_eks_worker_node_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.existing_policies_attach_to_eks_workers_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group_rule.egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.ingress_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.ingress_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.ingress_security_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.ingress_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_ami.eks_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_iam_instance_profile.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_instance_profile) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -235,11 +250,8 @@ Available targets:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional_security_group_ids"></a> [additional\_security\_group\_ids](#input\_additional\_security\_group\_ids) | Additional list of security groups that will be attached to the autoscaling group | `list(string)` | `[]` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | <a name="input_after_cluster_joining_userdata"></a> [after\_cluster\_joining\_userdata](#input\_after\_cluster\_joining\_userdata) | Additional commands to execute on each worker node after joining the EKS cluster (after executing the `bootstrap.sh` script). For mot info, see https://kubedex.com/90-days-of-aws-eks-in-production | `string` | `""` | no |
-| <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of CIDR blocks to be allowed to connect to the worker nodes | `list(string)` | `[]` | no |
-| <a name="input_allowed_security_groups"></a> [allowed\_security\_groups](#input\_allowed\_security\_groups) | List of Security Group IDs to be allowed to connect to the worker nodes | `list(string)` | `[]` | no |
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | Associate a public IP address with an instance in a VPC | `bool` | `false` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | <a name="input_autoscaling_group_tags"></a> [autoscaling\_group\_tags](#input\_autoscaling\_group\_tags) | Additional tags only for the autoscaling group, e.g. "k8s.io/cluster-autoscaler/node-template/taint/dedicated" = "ci-cd:NoSchedule". | `map(string)` | `{}` | no |
@@ -251,8 +263,6 @@ Available targets:
 | <a name="input_cluster_certificate_authority_data"></a> [cluster\_certificate\_authority\_data](#input\_cluster\_certificate\_authority\_data) | The base64 encoded certificate data required to communicate with the cluster | `string` | n/a | yes |
 | <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | EKS cluster endpoint | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the EKS cluster | `string` | n/a | yes |
-| <a name="input_cluster_security_group_id"></a> [cluster\_security\_group\_id](#input\_cluster\_security\_group\_id) | Security Group ID of the EKS cluster | `string` | n/a | yes |
-| <a name="input_cluster_security_group_ingress_enabled"></a> [cluster\_security\_group\_ingress\_enabled](#input\_cluster\_security\_group\_ingress\_enabled) | Whether to enable the EKS cluster Security Group as ingress to workers Security Group | `bool` | `true` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | <a name="input_cpu_utilization_high_evaluation_periods"></a> [cpu\_utilization\_high\_evaluation\_periods](#input\_cpu\_utilization\_high\_evaluation\_periods) | The number of periods over which data is compared to the specified threshold | `number` | `2` | no |
 | <a name="input_cpu_utilization_high_period_seconds"></a> [cpu\_utilization\_high\_period\_seconds](#input\_cpu\_utilization\_high\_period\_seconds) | The period in seconds over which the specified statistic is applied | `number` | `300` | no |
@@ -310,6 +320,11 @@ Available targets:
 | <a name="input_scale_up_cooldown_seconds"></a> [scale\_up\_cooldown\_seconds](#input\_scale\_up\_cooldown\_seconds) | The amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start | `number` | `300` | no |
 | <a name="input_scale_up_policy_type"></a> [scale\_up\_policy\_type](#input\_scale\_up\_policy\_type) | The scalling policy type, either `SimpleScaling`, `StepScaling` or `TargetTrackingScaling` | `string` | `"SimpleScaling"` | no |
 | <a name="input_scale_up_scaling_adjustment"></a> [scale\_up\_scaling\_adjustment](#input\_scale\_up\_scaling\_adjustment) | The number of instances by which to scale. `scale_up_adjustment_type` determines the interpretation of this number (e.g. as an absolute number or as a percentage of the existing Auto Scaling group size). A positive increment adds to the current capacity and a negative value removes from the current capacity | `number` | `1` | no |
+| <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | The Security Group description. | `string` | `"Security Group for EKS worker nodes"` | no |
+| <a name="input_security_group_enabled"></a> [security\_group\_enabled](#input\_security\_group\_enabled) | Whether to create default Security Group for EKS worker nodes. | `bool` | `true` | no |
+| <a name="input_security_group_rules"></a> [security\_group\_rules](#input\_security\_group\_rules) | A list of maps of Security Group rules. <br>The values of map is fully complated with `aws_security_group_rule` resource. <br>To get more info see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule . | `list(any)` | <pre>[<br>  {<br>    "cidr_blocks": [<br>      "0.0.0.0/0"<br>    ],<br>    "description": "Allow all outbound traffic",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "to_port": 65535,<br>    "type": "egress"<br>  }<br>]</pre> | no |
+| <a name="input_security_group_use_name_prefix"></a> [security\_group\_use\_name\_prefix](#input\_security\_group\_use\_name\_prefix) | Whether to create a default Security Group with unique name beginning with the normalized prefix. | `bool` | `false` | no |
+| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of Security Group IDs to associate with EKS worker nodes. | `list(string)` | `[]` | no |
 | <a name="input_service_linked_role_arn"></a> [service\_linked\_role\_arn](#input\_service\_linked\_role\_arn) | The ARN of the service-linked role that the ASG will use to call other AWS services | `string` | `""` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs to launch resources in | `list(string)` | n/a | yes |
@@ -319,13 +334,11 @@ Available targets:
 | <a name="input_termination_policies"></a> [termination\_policies](#input\_termination\_policies) | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default` | `list(string)` | <pre>[<br>  "Default"<br>]</pre> | no |
 | <a name="input_use_custom_image_id"></a> [use\_custom\_image\_id](#input\_use\_custom\_image\_id) | If set to `true`, will use variable `image_id` for the EKS workers inside autoscaling group | `bool` | `false` | no |
 | <a name="input_use_existing_aws_iam_instance_profile"></a> [use\_existing\_aws\_iam\_instance\_profile](#input\_use\_existing\_aws\_iam\_instance\_profile) | If set to `true`, will use variable `aws_iam_instance_profile_name` to run EKS workers using an existing AWS instance profile that was created outside of this module, workaround for error like `count cannot be computed` | `bool` | `false` | no |
-| <a name="input_use_existing_security_group"></a> [use\_existing\_security\_group](#input\_use\_existing\_security\_group) | If set to `true`, will use variable `workers_security_group_id` to run EKS workers using an existing security group that was created outside of this module, workaround for errors like `count cannot be computed` | `bool` | `false` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID for the EKS cluster | `string` | n/a | yes |
 | <a name="input_wait_for_capacity_timeout"></a> [wait\_for\_capacity\_timeout](#input\_wait\_for\_capacity\_timeout) | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | `string` | `"10m"` | no |
 | <a name="input_wait_for_elb_capacity"></a> [wait\_for\_elb\_capacity](#input\_wait\_for\_elb\_capacity) | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | `number` | `0` | no |
 | <a name="input_workers_role_policy_arns"></a> [workers\_role\_policy\_arns](#input\_workers\_role\_policy\_arns) | List of policy ARNs that will be attached to the workers default role on creation | `list(string)` | `[]` | no |
 | <a name="input_workers_role_policy_arns_count"></a> [workers\_role\_policy\_arns\_count](#input\_workers\_role\_policy\_arns\_count) | Count of policy ARNs that will be attached to the workers default role on creation. Needed to prevent Terraform error `count can't be computed` | `number` | `0` | no |
-| <a name="input_workers_security_group_id"></a> [workers\_security\_group\_id](#input\_workers\_security\_group\_id) | The name of the existing security group that will be used in autoscaling group for EKS workers. If empty, a new security group will be created | `string` | `""` | no |
 
 ## Outputs
 
@@ -503,8 +516,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] |
-|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Vladimir Syromyatnikov][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir Syromyatnikov][SweetOps_homepage] |
+|---|---|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
@@ -513,6 +526,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
   [goruha_homepage]: https://github.com/goruha
   [goruha_avatar]: https://img.cloudposse.com/150x150/https://github.com/goruha.png
+  [SweetOps_homepage]: https://github.com/SweetOps
+  [SweetOps_avatar]: https://img.cloudposse.com/150x150/https://github.com/SweetOps.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.yaml
+++ b/README.yaml
@@ -118,7 +118,27 @@ usage: |2-
       cluster_name                       = var.cluster_name
       cluster_endpoint                   = var.cluster_endpoint
       cluster_certificate_authority_data = var.cluster_certificate_authority_data
-      cluster_security_group_id          = var.cluster_security_group_id
+
+      security_group_rules = [
+        {
+          type                     = "egress"
+          from_port                = 0
+          to_port                  = 65535
+          protocol                 = "-1"
+          cidr_blocks              = ["0.0.0.0/0"]
+          source_security_group_id = null
+          description              = "Allow all outbound traffic"
+        },
+        {
+          type                     = "ingress"
+          from_port                = 0
+          to_port                  = 65535
+          protocol                 = "-1"
+          cidr_blocks              = []
+          source_security_group_id = "sg-XXXXXXXXX"
+          description              = "Allow all inbound traffic from Security Group ID of the EKS cluster"
+        }
+      ]
 
       # Auto-scaling policies and CloudWatch metric alarms
       autoscaling_policies_enabled           = var.autoscaling_policies_enabled
@@ -137,3 +157,5 @@ contributors:
     github: "aknysh"
   - name: "Igor Rodionov"
     github: "goruha"
+  - name: Vladimir Syromyatnikov
+    github: SweetOps

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -20,6 +20,7 @@
 |------|--------|---------|
 | <a name="module_autoscale_group"></a> [autoscale\_group](#module\_autoscale\_group) | cloudposse/ec2-autoscale-group/aws | 0.25.0 |
 | <a name="module_label"></a> [label](#module\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | cloudposse/security-group/aws | 0.3.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 
 ## Resources
@@ -32,12 +33,6 @@
 | [aws_iam_role_policy_attachment.amazon_eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.amazon_eks_worker_node_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.existing_policies_attach_to_eks_workers_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group_rule.egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.ingress_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.ingress_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.ingress_security_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.ingress_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_ami.eks_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_iam_instance_profile.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_instance_profile) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -47,11 +42,8 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional_security_group_ids"></a> [additional\_security\_group\_ids](#input\_additional\_security\_group\_ids) | Additional list of security groups that will be attached to the autoscaling group | `list(string)` | `[]` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | <a name="input_after_cluster_joining_userdata"></a> [after\_cluster\_joining\_userdata](#input\_after\_cluster\_joining\_userdata) | Additional commands to execute on each worker node after joining the EKS cluster (after executing the `bootstrap.sh` script). For mot info, see https://kubedex.com/90-days-of-aws-eks-in-production | `string` | `""` | no |
-| <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of CIDR blocks to be allowed to connect to the worker nodes | `list(string)` | `[]` | no |
-| <a name="input_allowed_security_groups"></a> [allowed\_security\_groups](#input\_allowed\_security\_groups) | List of Security Group IDs to be allowed to connect to the worker nodes | `list(string)` | `[]` | no |
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | Associate a public IP address with an instance in a VPC | `bool` | `false` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | <a name="input_autoscaling_group_tags"></a> [autoscaling\_group\_tags](#input\_autoscaling\_group\_tags) | Additional tags only for the autoscaling group, e.g. "k8s.io/cluster-autoscaler/node-template/taint/dedicated" = "ci-cd:NoSchedule". | `map(string)` | `{}` | no |
@@ -63,8 +55,6 @@
 | <a name="input_cluster_certificate_authority_data"></a> [cluster\_certificate\_authority\_data](#input\_cluster\_certificate\_authority\_data) | The base64 encoded certificate data required to communicate with the cluster | `string` | n/a | yes |
 | <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | EKS cluster endpoint | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the EKS cluster | `string` | n/a | yes |
-| <a name="input_cluster_security_group_id"></a> [cluster\_security\_group\_id](#input\_cluster\_security\_group\_id) | Security Group ID of the EKS cluster | `string` | n/a | yes |
-| <a name="input_cluster_security_group_ingress_enabled"></a> [cluster\_security\_group\_ingress\_enabled](#input\_cluster\_security\_group\_ingress\_enabled) | Whether to enable the EKS cluster Security Group as ingress to workers Security Group | `bool` | `true` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | <a name="input_cpu_utilization_high_evaluation_periods"></a> [cpu\_utilization\_high\_evaluation\_periods](#input\_cpu\_utilization\_high\_evaluation\_periods) | The number of periods over which data is compared to the specified threshold | `number` | `2` | no |
 | <a name="input_cpu_utilization_high_period_seconds"></a> [cpu\_utilization\_high\_period\_seconds](#input\_cpu\_utilization\_high\_period\_seconds) | The period in seconds over which the specified statistic is applied | `number` | `300` | no |
@@ -122,6 +112,11 @@
 | <a name="input_scale_up_cooldown_seconds"></a> [scale\_up\_cooldown\_seconds](#input\_scale\_up\_cooldown\_seconds) | The amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start | `number` | `300` | no |
 | <a name="input_scale_up_policy_type"></a> [scale\_up\_policy\_type](#input\_scale\_up\_policy\_type) | The scalling policy type, either `SimpleScaling`, `StepScaling` or `TargetTrackingScaling` | `string` | `"SimpleScaling"` | no |
 | <a name="input_scale_up_scaling_adjustment"></a> [scale\_up\_scaling\_adjustment](#input\_scale\_up\_scaling\_adjustment) | The number of instances by which to scale. `scale_up_adjustment_type` determines the interpretation of this number (e.g. as an absolute number or as a percentage of the existing Auto Scaling group size). A positive increment adds to the current capacity and a negative value removes from the current capacity | `number` | `1` | no |
+| <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | The Security Group description. | `string` | `"Security Group for EKS worker nodes"` | no |
+| <a name="input_security_group_enabled"></a> [security\_group\_enabled](#input\_security\_group\_enabled) | Whether to create default Security Group for EKS worker nodes. | `bool` | `true` | no |
+| <a name="input_security_group_rules"></a> [security\_group\_rules](#input\_security\_group\_rules) | A list of maps of Security Group rules. <br>The values of map is fully complated with `aws_security_group_rule` resource. <br>To get more info see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule . | `list(any)` | <pre>[<br>  {<br>    "cidr_blocks": [<br>      "0.0.0.0/0"<br>    ],<br>    "description": "Allow all outbound traffic",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "to_port": 65535,<br>    "type": "egress"<br>  }<br>]</pre> | no |
+| <a name="input_security_group_use_name_prefix"></a> [security\_group\_use\_name\_prefix](#input\_security\_group\_use\_name\_prefix) | Whether to create a default Security Group with unique name beginning with the normalized prefix. | `bool` | `false` | no |
+| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of Security Group IDs to associate with EKS worker nodes. | `list(string)` | `[]` | no |
 | <a name="input_service_linked_role_arn"></a> [service\_linked\_role\_arn](#input\_service\_linked\_role\_arn) | The ARN of the service-linked role that the ASG will use to call other AWS services | `string` | `""` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs to launch resources in | `list(string)` | n/a | yes |
@@ -131,13 +126,11 @@
 | <a name="input_termination_policies"></a> [termination\_policies](#input\_termination\_policies) | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default` | `list(string)` | <pre>[<br>  "Default"<br>]</pre> | no |
 | <a name="input_use_custom_image_id"></a> [use\_custom\_image\_id](#input\_use\_custom\_image\_id) | If set to `true`, will use variable `image_id` for the EKS workers inside autoscaling group | `bool` | `false` | no |
 | <a name="input_use_existing_aws_iam_instance_profile"></a> [use\_existing\_aws\_iam\_instance\_profile](#input\_use\_existing\_aws\_iam\_instance\_profile) | If set to `true`, will use variable `aws_iam_instance_profile_name` to run EKS workers using an existing AWS instance profile that was created outside of this module, workaround for error like `count cannot be computed` | `bool` | `false` | no |
-| <a name="input_use_existing_security_group"></a> [use\_existing\_security\_group](#input\_use\_existing\_security\_group) | If set to `true`, will use variable `workers_security_group_id` to run EKS workers using an existing security group that was created outside of this module, workaround for errors like `count cannot be computed` | `bool` | `false` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID for the EKS cluster | `string` | n/a | yes |
 | <a name="input_wait_for_capacity_timeout"></a> [wait\_for\_capacity\_timeout](#input\_wait\_for\_capacity\_timeout) | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior | `string` | `"10m"` | no |
 | <a name="input_wait_for_elb_capacity"></a> [wait\_for\_elb\_capacity](#input\_wait\_for\_elb\_capacity) | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior | `number` | `0` | no |
 | <a name="input_workers_role_policy_arns"></a> [workers\_role\_policy\_arns](#input\_workers\_role\_policy\_arns) | List of policy ARNs that will be attached to the workers default role on creation | `list(string)` | `[]` | no |
 | <a name="input_workers_role_policy_arns_count"></a> [workers\_role\_policy\_arns\_count](#input\_workers\_role\_policy\_arns\_count) | Count of policy ARNs that will be attached to the workers default role on creation. Needed to prevent Terraform error `count can't be computed` | `number` | `0` | no |
-| <a name="input_workers_security_group_id"></a> [workers\_security\_group\_id](#input\_workers\_security\_group\_id) | The name of the existing security group that will be used in autoscaling group for EKS workers. If empty, a new security group will be created | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -29,5 +29,3 @@ cluster_name = "eg-test-eks-workers-cluster"
 cluster_endpoint = ""
 
 cluster_certificate_authority_data = ""
-
-cluster_security_group_ingress_enabled = false

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -37,20 +37,39 @@ module "subnets" {
 module "eks_workers" {
   source = "../../"
 
-  instance_type                          = var.instance_type
-  vpc_id                                 = module.vpc.vpc_id
-  subnet_ids                             = module.subnets.public_subnet_ids
-  health_check_type                      = var.health_check_type
-  min_size                               = var.min_size
-  max_size                               = var.max_size
-  wait_for_capacity_timeout              = var.wait_for_capacity_timeout
-  cluster_name                           = var.cluster_name
-  cluster_endpoint                       = var.cluster_endpoint
-  cluster_certificate_authority_data     = var.cluster_certificate_authority_data
-  cluster_security_group_id              = var.cluster_security_group_id
-  cluster_security_group_ingress_enabled = var.cluster_security_group_ingress_enabled
-  bootstrap_extra_args                   = "--use-max-pods false"
-  kubelet_extra_args                     = "--node-labels=purpose=ci-worker"
+  instance_type                      = var.instance_type
+  vpc_id                             = module.vpc.vpc_id
+  subnet_ids                         = module.subnets.public_subnet_ids
+  health_check_type                  = var.health_check_type
+  min_size                           = var.min_size
+  max_size                           = var.max_size
+  wait_for_capacity_timeout          = var.wait_for_capacity_timeout
+  cluster_name                       = var.cluster_name
+  cluster_endpoint                   = var.cluster_endpoint
+  cluster_certificate_authority_data = var.cluster_certificate_authority_data
+  bootstrap_extra_args               = "--use-max-pods false"
+  kubelet_extra_args                 = "--node-labels=purpose=ci-worker"
+
+  security_group_rules = [
+    {
+      type                     = "egress"
+      from_port                = 0
+      to_port                  = 65535
+      protocol                 = "-1"
+      cidr_blocks              = ["0.0.0.0/0"]
+      source_security_group_id = null
+      description              = "Allow all outbound traffic"
+    },
+    {
+      type                     = "ingress"
+      from_port                = 0
+      to_port                  = 65535
+      protocol                 = "-1"
+      cidr_blocks              = []
+      source_security_group_id = module.vpc.vpc_default_security_group_id
+      description              = "Allow all inbound traffic from trusted Security Groups"
+    },
+  ]
 
   # Auto-scaling policies and CloudWatch metric alarms
   autoscaling_policies_enabled           = var.autoscaling_policies_enabled

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -24,17 +24,6 @@ variable "cluster_certificate_authority_data" {
   description = "The base64 encoded certificate data required to communicate with the cluster"
 }
 
-variable "cluster_security_group_ingress_enabled" {
-  type        = bool
-  description = "Whether to enable the EKS cluster Security Group as ingress to workers Security Group"
-}
-
-variable "cluster_security_group_id" {
-  type        = string
-  description = "Security Group ID of the EKS cluster"
-  default     = ""
-}
-
 variable "instance_type" {
   type        = string
   description = "Instance type to launch"

--- a/main.tf
+++ b/main.tf
@@ -4,8 +4,9 @@ locals {
     "kubernetes.io/cluster/${var.cluster_name}" = "owned"
   }
 
-  workers_role_arn  = var.use_existing_aws_iam_instance_profile ? join("", data.aws_iam_instance_profile.default.*.role_arn) : join("", aws_iam_role.default.*.arn)
-  workers_role_name = var.use_existing_aws_iam_instance_profile ? join("", data.aws_iam_instance_profile.default.*.role_name) : join("", aws_iam_role.default.*.name)
+  workers_role_arn       = var.use_existing_aws_iam_instance_profile ? join("", data.aws_iam_instance_profile.default.*.role_arn) : join("", aws_iam_role.default.*.arn)
+  workers_role_name      = var.use_existing_aws_iam_instance_profile ? join("", data.aws_iam_instance_profile.default.*.role_name) : join("", aws_iam_role.default.*.name)
+  security_group_enabled = module.this.enabled && var.security_group_enabled
 }
 
 module "label" {
@@ -69,67 +70,17 @@ resource "aws_iam_instance_profile" "default" {
   role  = join("", aws_iam_role.default.*.name)
 }
 
-resource "aws_security_group" "default" {
-  count       = local.enabled && var.use_existing_security_group == false ? 1 : 0
-  name        = module.label.id
-  description = "Security Group for EKS worker nodes"
-  vpc_id      = var.vpc_id
-  tags        = module.label.tags
-}
+module "security_group" {
+  source  = "cloudposse/security-group/aws"
+  version = "0.3.1"
 
-resource "aws_security_group_rule" "egress" {
-  count             = local.enabled && var.use_existing_security_group == false ? 1 : 0
-  description       = "Allow all egress traffic"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = join("", aws_security_group.default.*.id)
-  type              = "egress"
-}
+  use_name_prefix = var.security_group_use_name_prefix
+  rules           = var.security_group_rules
+  description     = var.security_group_description
+  vpc_id          = var.vpc_id
 
-resource "aws_security_group_rule" "ingress_self" {
-  count                    = local.enabled && var.use_existing_security_group == false ? 1 : 0
-  description              = "Allow nodes to communicate with each other"
-  from_port                = 0
-  to_port                  = 65535
-  protocol                 = "-1"
-  security_group_id        = join("", aws_security_group.default.*.id)
-  source_security_group_id = join("", aws_security_group.default.*.id)
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "ingress_cluster" {
-  count                    = local.enabled && var.cluster_security_group_ingress_enabled && var.use_existing_security_group == false ? 1 : 0
-  description              = "Allow worker kubelets and pods to receive communication from the cluster control plane"
-  from_port                = 0
-  to_port                  = 65535
-  protocol                 = "-1"
-  security_group_id        = join("", aws_security_group.default.*.id)
-  source_security_group_id = var.cluster_security_group_id
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "ingress_security_groups" {
-  count                    = local.enabled && var.use_existing_security_group == false ? length(var.allowed_security_groups) : 0
-  description              = "Allow inbound traffic from existing Security Groups"
-  from_port                = 0
-  to_port                  = 65535
-  protocol                 = "-1"
-  source_security_group_id = var.allowed_security_groups[count.index]
-  security_group_id        = join("", aws_security_group.default.*.id)
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "ingress_cidr_blocks" {
-  count             = local.enabled && length(var.allowed_cidr_blocks) > 0 && var.use_existing_security_group == false ? 1 : 0
-  description       = "Allow inbound traffic from CIDR blocks"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = var.allowed_cidr_blocks
-  security_group_id = join("", aws_security_group.default.*.id)
-  type              = "ingress"
+  enabled = local.security_group_enabled
+  context = module.this.context
 }
 
 data "aws_ami" "eks_worker" {
@@ -176,14 +127,7 @@ module "autoscale_group" {
   image_id                  = var.use_custom_image_id ? var.image_id : join("", data.aws_ami.eks_worker.*.id)
   iam_instance_profile_name = var.use_existing_aws_iam_instance_profile == false ? join("", aws_iam_instance_profile.default.*.name) : var.aws_iam_instance_profile_name
 
-  security_group_ids = compact(
-    concat(
-      [
-        var.use_existing_security_group == false ? join("", aws_security_group.default.*.id) : var.workers_security_group_id
-      ],
-      var.additional_security_group_ids
-    )
-  )
+  security_group_ids = compact(concat(module.security_group.*.id, var.security_groups))
 
   user_data_base64 = base64encode(join("", data.template_file.userdata.*.rendered))
 

--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ module "security_group" {
   vpc_id          = var.vpc_id
 
   enabled = local.security_group_enabled
-  context = module.this.context
+  context = module.label.context
 }
 
 data "aws_ami" "eks_worker" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,17 +60,17 @@ output "autoscaling_group_health_check_type" {
 
 output "security_group_id" {
   description = "ID of the worker nodes Security Group"
-  value       = join("", aws_security_group.default.*.id)
+  value       = module.security_group.id
 }
 
 output "security_group_arn" {
   description = "ARN of the worker nodes Security Group"
-  value       = join("", aws_security_group.default.*.arn)
+  value       = module.security_group.arn
 }
 
 output "security_group_name" {
   description = "Name of the worker nodes Security Group"
-  value       = join("", aws_security_group.default.*.name)
+  value       = module.security_group.name
 }
 
 output "workers_role_arn" {

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -60,16 +60,16 @@ func TestExamplesComplete(t *testing.T) {
 	// autoscaling_group_name = eg-test-suite-20210416185727403200000006
 	autoscalingGroupName := terraform.Output(t, terraformOptions, "autoscaling_group_name")
 	// Verify we're getting back the outputs we expect
-	assert.Regexp(t, regexp.MustCompile(`^` + expectedPrefix + `-\d+$`) , autoscalingGroupName, "Autoscaling Group name should be our expected prefix plus a random suffix")
+	assert.Regexp(t, regexp.MustCompile(`^`+expectedPrefix+`-\d+$`), autoscalingGroupName, "Autoscaling Group name should be our expected prefix plus a random suffix")
 
 	// Run `terraform output` to get the value of an output variable
 	var tags []TerraformMapString
 
 	terraform.OutputStruct(t, terraformOptions, "autoscaling_group_tags", &tags)
 	expectedTag := TerraformMapString{
-			"key":                 "Name",
-			"value":               expectedPrefix,
-			"propagate_at_launch": "true",
+		"key":                 "Name",
+		"value":               expectedPrefix,
+		"propagate_at_launch": "true",
 	}
 
 	assert.Contains(t, tags, expectedTag, `Tag "Name" should match eks-workers module ID`)
@@ -88,15 +88,25 @@ func TestExamplesComplete(t *testing.T) {
 	launchTemplateId := terraform.Output(t, terraformOptions, "launch_template_id")
 	// Verify we're getting back the outputs we expect
 	// arn:aws:ec2:us-east-2:126450723953:launch-template/
-	assert.Equal(t, "arn:aws:ec2:us-east-2:126450723953:launch-template/" + launchTemplateId, launchTemplateArn)
+	assert.Equal(t, "arn:aws:ec2:us-east-2:126450723953:launch-template/"+launchTemplateId, launchTemplateArn)
 
 	// Run `terraform output` to get the value of an output variable
 	securityGroupName := terraform.Output(t, terraformOptions, "security_group_name")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, expectedPrefix + "-workers", securityGroupName)
+	assert.Equal(t, expectedPrefix+"-workers", securityGroupName)
+
+	// Run `terraform output` to get the value of an output variable
+	securityGroupID := terraform.Output(t, terraformOptions, "security_group_id")
+	// Verify we're getting back the outputs we expect
+	assert.Contains(t, securityGroupID, "sg-", "SG ID should contains substring 'sg-'")
+
+	// Run `terraform output` to get the value of an output variable
+	securityGroupARN := terraform.Output(t, terraformOptions, "security_group_arn")
+	// Verify we're getting back the outputs we expect
+	assert.Contains(t, securityGroupARN, "arn:aws:ec2", "SG ID should contains substring 'arn:aws:ec2'")
 
 	// Run `terraform output` to get the value of an output variable
 	workerRoleName := terraform.Output(t, terraformOptions, "workers_role_name")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, expectedPrefix + "-workers", workerRoleName)
+	assert.Equal(t, expectedPrefix+"-workers", workerRoleName)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,32 +13,52 @@ variable "cluster_certificate_authority_data" {
   description = "The base64 encoded certificate data required to communicate with the cluster"
 }
 
-variable "cluster_security_group_ingress_enabled" {
-  type        = bool
-  description = "Whether to enable the EKS cluster Security Group as ingress to workers Security Group"
-  default     = true
-}
-
-variable "cluster_security_group_id" {
-  type        = string
-  description = "Security Group ID of the EKS cluster"
-}
-
 variable "vpc_id" {
   type        = string
   description = "VPC ID for the EKS cluster"
 }
 
-variable "allowed_security_groups" {
-  type        = list(string)
-  default     = []
-  description = "List of Security Group IDs to be allowed to connect to the worker nodes"
+variable "security_group_enabled" {
+  type        = bool
+  description = "Whether to create default Security Group for EKS worker nodes."
+  default     = true
 }
 
-variable "allowed_cidr_blocks" {
+variable "security_group_description" {
+  type        = string
+  default     = "Security Group for EKS worker nodes"
+  description = "The Security Group description."
+}
+
+variable "security_group_use_name_prefix" {
+  type        = bool
+  default     = false
+  description = "Whether to create a default Security Group with unique name beginning with the normalized prefix."
+}
+
+variable "security_group_rules" {
+  type = list(any)
+  default = [
+    {
+      type        = "egress"
+      from_port   = 0
+      to_port     = 65535
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "Allow all outbound traffic"
+    }
+  ]
+  description = <<-EOT
+    A list of maps of Security Group rules. 
+    The values of map is fully complated with `aws_security_group_rule` resource. 
+    To get more info see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule .
+  EOT
+}
+
+variable "security_groups" {
   type        = list(string)
   default     = []
-  description = "List of CIDR blocks to be allowed to connect to the worker nodes"
+  description = "A list of Security Group IDs to associate with EKS worker nodes."
 }
 
 variable "metadata_http_endpoint_enabled" {
@@ -385,24 +405,6 @@ variable "aws_iam_instance_profile_name" {
   type        = string
   default     = ""
   description = "The name of the existing instance profile that will be used in autoscaling group for EKS workers. If empty will create a new instance profile."
-}
-
-variable "workers_security_group_id" {
-  type        = string
-  default     = ""
-  description = "The name of the existing security group that will be used in autoscaling group for EKS workers. If empty, a new security group will be created"
-}
-
-variable "use_existing_security_group" {
-  type        = bool
-  description = "If set to `true`, will use variable `workers_security_group_id` to run EKS workers using an existing security group that was created outside of this module, workaround for errors like `count cannot be computed`"
-  default     = false
-}
-
-variable "additional_security_group_ids" {
-  type        = list(string)
-  default     = []
-  description = "Additional list of security groups that will be attached to the autoscaling group"
 }
 
 variable "use_existing_aws_iam_instance_profile" {


### PR DESCRIPTION
## what
* use security-group module instead of resource
* update tests

## why
* more flexible  than current implementation 
* bring configuration of security group/rules to one standard

## references
* CPCO-409
