### PR TITLE
Support other AWS partitions other than Commercial

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Available targets:
 | [aws_ami.eks_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_iam_instance_profile.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_instance_profile) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -39,6 +39,7 @@
 | [aws_ami.eks_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_iam_instance_profile.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_instance_profile) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,8 @@ module "label" {
   context = module.this.context
 }
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "assume_role" {
   count = local.enabled && var.use_existing_aws_iam_instance_profile == false ? 1 : 0
 
@@ -51,19 +53,19 @@ resource "aws_iam_role" "default" {
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_worker_node_policy" {
   count      = local.enabled && var.use_existing_aws_iam_instance_profile == false ? 1 : 0
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
   role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_cni_policy" {
   count      = local.enabled && var.use_existing_aws_iam_instance_profile == false ? 1 : 0
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
   role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_ec2_container_registry_read_only" {
   count      = local.enabled && var.use_existing_aws_iam_instance_profile == false ? 1 : 0
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
   role       = join("", aws_iam_role.default.*.name)
 }
 


### PR DESCRIPTION
Useful for deploying to GovCloud since their partition there is "aws-us-gov" instead of just "aws"

## what
Support other AWS partitions by templatizing ARNs that are currently hard coded

## why
So the module can be used in other AWS partitions like GovCloud

## references
Closes #92 

