### PR TITLE
chore: fix tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -165,7 +165,7 @@ data "aws_iam_instance_profile" "default" {
 
 module "autoscale_group" {
   source  = "cloudposse/ec2-autoscale-group/aws"
-  version = "0.30.1"
+  version = "0.39.0"
 
   enabled = local.enabled
   tags    = merge(local.tags, var.autoscaling_group_tags)


### PR DESCRIPTION
│ Error: Unsupported argument
│
│   on .terraform/modules/eks_workers.autoscale_group/main.tf line 244, in resource "aws_autoscaling_group" "default":
│  244:   tags = flatten([
│
│ An argument named "tags" is not expected here.

## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
